### PR TITLE
네비게이션 바가 두 개 나타나는 현상 수정

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { styled } from 'styled-components';
 import CafeCard from '../components/CafeCard';
-import Navbar from '../components/Navbar';
 import useCafes from '../hooks/useCafes';
 
 const PREFETCH_OFFSET = 2;
@@ -31,33 +30,20 @@ const Home = () => {
   }
 
   return (
-    <Container>
-      <CardList>
-        {cafes.map((cafe, index) => (
-          <CafeCard key={cafe.id} cafe={cafe} onIntersect={handleCafeChange[index]} />
-        ))}
-      </CardList>
-      <Navbar />
-    </Container>
+    <CardList>
+      {cafes.map((cafe, index) => (
+        <CafeCard key={cafe.id} cafe={cafe} onIntersect={handleCafeChange[index]} />
+      ))}
+    </CardList>
   );
 };
 
 export default Home;
 
-const Container = styled.main`
-  position: relative;
-
-  display: flex;
-  flex-direction: column;
-
-  width: 100%;
-  height: 100%;
-`;
-
 const CardList = styled.ul`
   scroll-snap-type: y mandatory;
   overflow-y: scroll;
-  flex: 1;
+  height: 100%;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #62 

## 📝 작업 내용

<img width="400" src="https://github.com/woowacourse-teams/2023-yozm-cafe/assets/20203944/317c0e51-8df6-44be-9116-481f3524146e">

네비게이션 바가 두 개 나타나는 현상을 수정하였습니다.

## 💬 리뷰 요구사항