### PR TITLE
멤버가 확인한 카페정보를 UnViewedCafe 에서 삭제하는 기능 개발

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 
     //DB
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/Cafe.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/Cafe.java
@@ -25,4 +25,41 @@ public class Cafe {
     @Embedded
     private Detail detail;
     private int likeCount;
+
+    protected Cafe() {
+    }
+
+    public Cafe(final Long id, final String name, final String address, final Images images, final Detail detail,
+                final int likeCount) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.images = images;
+        this.detail = detail;
+        this.likeCount = likeCount;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public Images getImages() {
+        return images;
+    }
+
+    public Detail getDetail() {
+        return detail;
+    }
+
+    public int getLikeCount() {
+        return likeCount;
+    }
 }

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/CafeRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/CafeRepository.java
@@ -1,8 +1,6 @@
 package com.project.yozmcafe.domain.cafe;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface CafeRepository extends JpaRepository<Cafe, Long> {
 }

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafe.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafe.java
@@ -20,4 +20,34 @@ public class UnViewedCafe {
 
     @ManyToOne
     private Member member;
+
+    protected UnViewedCafe() {
+    }
+
+    public UnViewedCafe(final Long id, final Cafe cafe, final Member member) {
+        this.id = id;
+        this.cafe = cafe;
+        this.member = member;
+    }
+
+    public void remove() {
+        this.member = null;
+        this.cafe = null;
+    }
+
+    public boolean isMatch(Member member, Cafe cafe) {
+        return this.member.equals(member) && this.cafe.equals(cafe);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Cafe getCafe() {
+        return cafe;
+    }
+
+    public Member getMember() {
+        return member;
+    }
 }

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafe.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafe.java
@@ -39,10 +39,6 @@ public class UnViewedCafe {
         return this.member.equals(member) && this.cafe.equals(cafe);
     }
 
-    public void setMember(final Member member) {
-        this.member = member;
-    }
-
     public Long getId() {
         return id;
     }

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafe.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafe.java
@@ -35,8 +35,12 @@ public class UnViewedCafe {
         this.cafe = null;
     }
 
-    public boolean isMatch(Member member, Cafe cafe) {
+    public boolean isMatch(final Member member, final Cafe cafe) {
         return this.member.equals(member) && this.cafe.equals(cafe);
+    }
+
+    public void setMember(final Member member) {
+        this.member = member;
     }
 
     public Long getId() {

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafeRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/UnViewedCafeRepository.java
@@ -1,0 +1,6 @@
+package com.project.yozmcafe.domain.cafe;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UnViewedCafeRepository extends JpaRepository<UnViewedCafe, Long> {
+}

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -1,10 +1,13 @@
 package com.project.yozmcafe.domain.member;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import com.project.yozmcafe.domain.cafe.Cafe;
 import com.project.yozmcafe.domain.cafe.LikedCafe;
 import com.project.yozmcafe.domain.cafe.UnViewedCafe;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,9 +20,45 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<UnViewedCafe> unViewedCafes;
 
     @OneToMany(mappedBy = "member")
     private List<LikedCafe> likedCafes;
+
+    protected Member() {
+    }
+
+    public Member(final Long id) {
+        this.id = id;
+        this.unViewedCafes = new ArrayList<>();
+        this.likedCafes = new ArrayList<>();
+    }
+
+    public void addUnViewedCafe(final UnViewedCafe unViewedCafe) {
+        unViewedCafe.setMember(this);
+        this.unViewedCafes.add(unViewedCafe);
+    }
+
+    public void removeUnViewedCafe(final Cafe cafe) {
+        final UnViewedCafe foundUnviewedCafe = unViewedCafes.stream()
+                .filter(unViewedCafe -> unViewedCafe.isMatch(this, cafe))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 내역입니다."));
+
+        this.unViewedCafes.remove(foundUnviewedCafe);
+        foundUnviewedCafe.remove();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public List<UnViewedCafe> getUnViewedCafes() {
+        return unViewedCafes;
+    }
+
+    public List<LikedCafe> getLikedCafes() {
+        return likedCafes;
+    }
 }

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -35,9 +35,8 @@ public class Member {
         this.likedCafes = new ArrayList<>();
     }
 
-    public void addUnViewedCafe(final UnViewedCafe unViewedCafe) {
-        unViewedCafe.setMember(this);
-        this.unViewedCafes.add(unViewedCafe);
+    public void addUnViewedCafes(final List<UnViewedCafe> unViewedCafes) {
+        this.unViewedCafes.addAll(unViewedCafes);
     }
 
     public void removeUnViewedCafe(final Cafe cafe) {

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -50,6 +50,10 @@ public class Member {
         foundUnviewedCafe.remove();
     }
 
+    public boolean isEmptyUnViewedCafe() {
+        return this.unViewedCafes.isEmpty();
+    }
+
     public Long getId() {
         return id;
     }

--- a/server/src/main/java/com/project/yozmcafe/domain/member/MemberRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/MemberRepository.java
@@ -1,8 +1,6 @@
 package com.project.yozmcafe.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/server/src/main/java/com/project/yozmcafe/service/CafeHistoryService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeHistoryService.java
@@ -38,10 +38,10 @@ public class CafeHistoryService {
     private void updateUnViewedCafes(final Member member) {
         final List<Cafe> allCafes = cafes.findAll();
         Collections.shuffle(allCafes);
-        final List<UnViewedCafe> unViewedCafes = allCafes.stream()
+        final List<UnViewedCafe> allUnViewedCafes = allCafes.stream()
                 .map(savedCafe -> new UnViewedCafe(null, savedCafe, member))
                 .toList();
-        this.unViewedCafes.saveAll(unViewedCafes);
-        member.addUnViewedCafes(unViewedCafes);
+        this.unViewedCafes.saveAll(allUnViewedCafes);
+        member.addUnViewedCafes(allUnViewedCafes);
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/service/CafeHistoryService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeHistoryService.java
@@ -1,0 +1,47 @@
+package com.project.yozmcafe.service;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.CafeRepository;
+import com.project.yozmcafe.domain.cafe.UnViewedCafe;
+import com.project.yozmcafe.domain.cafe.UnViewedCafeRepository;
+import com.project.yozmcafe.domain.member.Member;
+
+@Service
+@Transactional(readOnly = true)
+public class CafeHistoryService {
+
+    private final CafeRepository cafes;
+    private final UnViewedCafeRepository unViewedCafes;
+
+    public CafeHistoryService(final CafeRepository cafes, final UnViewedCafeRepository unViews) {
+        this.cafes = cafes;
+        this.unViewedCafes = unViews;
+    }
+
+    @Transactional
+    public void removeUnViewedCafe(final Member member, final long cafeId) {
+        final Cafe cafe = cafes.findById(cafeId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카페입니다."));
+        member.removeUnViewedCafe(cafe);
+
+        if (member.isEmptyUnViewedCafe()) {
+            updateUnViewedCafes(member);
+        }
+    }
+
+    private void updateUnViewedCafes(final Member member) {
+        final List<Cafe> allCafes = cafes.findAll();
+        Collections.shuffle(allCafes);
+        final List<UnViewedCafe> unViewedCafes = allCafes.stream()
+                .map(savedCafe -> new UnViewedCafe(null, savedCafe, member))
+                .toList();
+        this.unViewedCafes.saveAll(unViewedCafes);
+        member.addUnViewedCafes(unViewedCafes);
+    }
+}

--- a/server/src/test/java/com/project/yozmcafe/domain/cafe/UnViewedCafeTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/cafe/UnViewedCafeTest.java
@@ -1,0 +1,58 @@
+package com.project.yozmcafe.domain.cafe;
+
+import static com.project.yozmcafe.fixture.Fixture.CAFE_1;
+import static com.project.yozmcafe.fixture.Fixture.CAFE_2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.project.yozmcafe.domain.member.Member;
+
+class UnViewedCafeTest {
+
+    private static final Member MEMBER = new Member(1L);
+    private UnViewedCafe unViewedCafe;
+
+    @BeforeEach
+    void setUp() {
+        unViewedCafe = new UnViewedCafe(null, CAFE_1, MEMBER);
+    }
+
+    @Test
+    @DisplayName("멤버와 카페를 null로 변경한다.")
+    void remove() {
+        //when
+        unViewedCafe.remove();
+
+        //then
+        assertThat(unViewedCafe.getCafe()).isNull();
+        assertThat(unViewedCafe.getMember()).isNull();
+    }
+
+    @MethodSource("provideExpectAndParams")
+    @DisplayName("멤버와 카페가 일치하면 true를 반환한다. 일치하지 않으면 false를 반환한다.")
+    @ParameterizedTest
+    void isMatch(Member member, Cafe cafe, boolean expect) {
+        final boolean result = unViewedCafe.isMatch(member, cafe);
+
+        //then
+        assertThat(result).isEqualTo(expect);
+    }
+
+    public static Stream<Arguments> provideExpectAndParams() {
+        return Stream.of(
+                Arguments.of(MEMBER, CAFE_1, true),
+                Arguments.of(MEMBER, CAFE_2, false),
+                Arguments.of(new Member(2L), CAFE_2, false),
+                Arguments.of(null, CAFE_2, false),
+                Arguments.of(MEMBER, null, false)
+        );
+    }
+}

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -3,6 +3,8 @@ package com.project.yozmcafe.domain.member;
 import static com.project.yozmcafe.fixture.Fixture.CAFE_1;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,9 +20,7 @@ class MemberTest {
         final UnViewedCafe unViewedCafe1 = new UnViewedCafe(null, CAFE_1, member);
         final UnViewedCafe unViewedCafe2 = new UnViewedCafe(null, CAFE_1, member);
         final UnViewedCafe unViewedCafe3 = new UnViewedCafe(null, CAFE_1, member);
-        member.addUnViewedCafe(unViewedCafe1);
-        member.addUnViewedCafe(unViewedCafe2);
-        member.addUnViewedCafe(unViewedCafe3);
+        member.addUnViewedCafes(List.of(unViewedCafe1, unViewedCafe2, unViewedCafe3));
 
         //when
         member.removeUnViewedCafe(CAFE_1);

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -1,0 +1,32 @@
+package com.project.yozmcafe.domain.member;
+
+import static com.project.yozmcafe.fixture.Fixture.CAFE_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.project.yozmcafe.domain.cafe.UnViewedCafe;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("회원의 unViewedCafe 기록을 삭제한다.")
+    void removeUnViewedCafe() {
+        //given
+        Member member = new Member(1L);
+        final UnViewedCafe unViewedCafe1 = new UnViewedCafe(null, CAFE_1, member);
+        final UnViewedCafe unViewedCafe2 = new UnViewedCafe(null, CAFE_1, member);
+        final UnViewedCafe unViewedCafe3 = new UnViewedCafe(null, CAFE_1, member);
+        member.addUnViewedCafe(unViewedCafe1);
+        member.addUnViewedCafe(unViewedCafe2);
+        member.addUnViewedCafe(unViewedCafe3);
+
+        //when
+        member.removeUnViewedCafe(CAFE_1);
+
+        //then
+        assertThat(member.getUnViewedCafes()).hasSize(2);
+    }
+
+}

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -29,4 +29,16 @@ class MemberTest {
         assertThat(member.getUnViewedCafes()).hasSize(2);
     }
 
+    @Test
+    @DisplayName("멤버의 unViewedCafes가 비어있으면 true를 반환한다.")
+    void isEmptyUnViewedCafe() {
+        //given
+        final Member member = new Member(1L);
+
+        //when
+        final boolean result = member.isEmptyUnViewedCafe();
+
+        //then
+        assertThat(result).isTrue();
+    }
 }

--- a/server/src/test/java/com/project/yozmcafe/fixture/Fixture.java
+++ b/server/src/test/java/com/project/yozmcafe/fixture/Fixture.java
@@ -1,0 +1,68 @@
+package com.project.yozmcafe.fixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.Detail;
+import com.project.yozmcafe.domain.cafe.Images;
+import com.project.yozmcafe.domain.cafe.available.AvailableTime;
+import com.project.yozmcafe.domain.cafe.available.Days;
+
+public class Fixture {
+    public static final Detail DETAIL_1 = new Detail(
+            List.of(new AvailableTime(Days.MONDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.TUESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.WEDNESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.THURSDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.FRIDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SATURDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SUNDAY, LocalDateTime.now(), LocalDateTime.now(), true))
+            , "mapUrl", "desc");
+    public static final Detail DETAIL_2 = new Detail(
+            List.of(new AvailableTime(Days.MONDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.TUESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.WEDNESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.THURSDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.FRIDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SATURDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SUNDAY, LocalDateTime.now(), LocalDateTime.now(), true))
+            , "mapUrl", "desc");
+    public static final Detail DETAIL_3 = new Detail(
+            List.of(new AvailableTime(Days.MONDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.TUESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.WEDNESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.THURSDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.FRIDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SATURDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SUNDAY, LocalDateTime.now(), LocalDateTime.now(), true))
+            , "mapUrl", "desc");
+    public static final Detail DETAIL_4 = new Detail(
+            List.of(new AvailableTime(Days.MONDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.TUESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.WEDNESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.THURSDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.FRIDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SATURDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SUNDAY, LocalDateTime.now(), LocalDateTime.now(), true))
+            , "mapUrl", "desc");
+    public static final Detail DETAIL_5 = new Detail(
+            List.of(new AvailableTime(Days.MONDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.TUESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.WEDNESDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.THURSDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.FRIDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SATURDAY, LocalDateTime.now(), LocalDateTime.now(), true),
+                    new AvailableTime(Days.SUNDAY, LocalDateTime.now(), LocalDateTime.now(), true))
+            , "mapUrl", "desc");
+    public static final Images IMAGES_1 = new Images(List.of("image1", "image2"));
+    public static final Images IMAGES_2 = new Images(List.of("image1", "image2"));
+    public static final Images IMAGES_3 = new Images(List.of("image1", "image2"));
+    public static final Images IMAGES_4 = new Images(List.of("image1", "image2"));
+    public static final Images IMAGES_5 = new Images(List.of("image1", "image2"));
+    public static final Cafe CAFE_1 = new Cafe(null, "카페1", "카페주소1", IMAGES_1, DETAIL_1, 10);
+    public static final Cafe CAFE_2 = new Cafe(null, "카페2", "카페주소2", IMAGES_2, DETAIL_2, 11);
+    public static final Cafe CAFE_3 = new Cafe(null, "카페3", "카페주소3", IMAGES_3, DETAIL_3, 12);
+    public static final Cafe CAFE_4 = new Cafe(null, "카페4", "카페주소4", IMAGES_4, DETAIL_4, 13);
+    public static final Cafe CAFE_5 = new Cafe(null, "카페5", "카페주소5", IMAGES_5, DETAIL_5, 14);
+}

--- a/server/src/test/java/com/project/yozmcafe/service/CafeHistoryServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/CafeHistoryServiceTest.java
@@ -1,0 +1,81 @@
+package com.project.yozmcafe.service;
+
+import static com.project.yozmcafe.fixture.Fixture.CAFE_1;
+import static com.project.yozmcafe.fixture.Fixture.CAFE_2;
+import static com.project.yozmcafe.fixture.Fixture.CAFE_3;
+import static com.project.yozmcafe.fixture.Fixture.CAFE_4;
+import static com.project.yozmcafe.fixture.Fixture.CAFE_5;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.CafeRepository;
+import com.project.yozmcafe.domain.cafe.UnViewedCafe;
+import com.project.yozmcafe.domain.cafe.UnViewedCafeRepository;
+import com.project.yozmcafe.domain.member.Member;
+import com.project.yozmcafe.domain.member.MemberRepository;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class CafeHistoryServiceTest {
+
+    private CafeHistoryService cafeHistoryService;
+
+    @Autowired
+    private CafeRepository cafes;
+
+    @Autowired
+    private UnViewedCafeRepository unViewedCafes;
+
+    @Autowired
+    private MemberRepository members;
+
+    @BeforeEach
+    void setUp() {
+        cafeHistoryService = new CafeHistoryService(cafes, unViewedCafes);
+    }
+
+    @Test
+    @DisplayName("사용자의 unViewedCafe를 삭제한다.")
+    void removeUnViewedCafe() {
+        //given
+        final Member member = new Member(null);
+        final Cafe cafe1 = cafes.save(CAFE_4);
+        final Cafe cafe2 = cafes.save(CAFE_5);
+        final UnViewedCafe unViewedCafe1 = unViewedCafes.save(new UnViewedCafe(null, cafe1, member));
+        final UnViewedCafe unViewedCafe2 = unViewedCafes.save(new UnViewedCafe(null, cafe2, member));
+        member.addUnViewedCafes(List.of(unViewedCafe1, unViewedCafe2));
+
+        //when
+        cafeHistoryService.removeUnViewedCafe(member, cafe1.getId());
+
+        //then
+        assertThat(member.getUnViewedCafes()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("사용자의 unViewedCafe를 삭제하고 unViewedCafe가 비어있다면, 모든 카페를 넣는다.")
+    void removeUnViewedCafeWhenEmpty() {
+        final Member member = members.save(new Member(null));
+        final Cafe cafe1 = cafes.save(CAFE_1);
+        final Cafe cafe2 = cafes.save(CAFE_2);
+        final Cafe cafe3 = cafes.save(CAFE_3);
+        final UnViewedCafe unViewedCafe1 = unViewedCafes.save(new UnViewedCafe(null, cafe1, member));
+        member.addUnViewedCafes(List.of(unViewedCafe1));
+
+        //when
+        cafeHistoryService.removeUnViewedCafe(member, cafe1.getId());
+
+        //then
+        assertThat(member.getUnViewedCafes()).hasSize(3);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요
> resolved #71 

## 📝 작업 내용

> - [x] 사용자가 조회한 카페를 UnViewedCafe 테이블에서 삭제한다.
>     - Member의 List<UnViewedCafe>에 orphanRemoval과 cascade.all 이용함.
> - [x] 사용자의 UnViewedCafe가 모두 삭제 되었을 시, 다시 카페 정보를 갱신한다.
>     - [x] 카페정보를 unViewedCafe에 넣을시에 순서를 랜덤하게 정렬하여 저장한다. 
>     - `jdbcTemplate.batchUpdate()` 사용하려 했으나, batchUpdate 이후 생성된 Id 또는 객체를 가져올 수 없어, JPA saveAll 로 구현


## 💬 리뷰 요구사항

> `jdbcTemplate.batchUpdate()` 사용하려 했으나, batchUpdate 이후 생성된 Id 또는 객체를 가져올 수 없어, JPA saveAll 로 구현한 부분 혹시 더 좋은 개선 방향이 있으면 알려주세용
