### PR TITLE
홈 화면에서 스와이프 시 하나의 카드만 넘어갈 수 있게 수정

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -51,6 +51,7 @@ const CardList = styled.ul`
 
   & > * {
     scroll-snap-align: start;
+    scroll-snap-stop: always;
     margin-bottom: 40px;
   }
 `;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #55 

## 📝 작업 내용

- [x] `scroll-snap-stop: always` 스와이프 시 하나의 카드만 넘어갈 수 있게 수정

## 💬 리뷰 요구사항
