### PR TITLE
홈 화면의 카페 카드 사이에 불필요한 마진 삭제

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -51,6 +51,5 @@ const CardList = styled.ul`
 
   & > * {
     scroll-snap-align: start;
-    margin-bottom: 40px;
   }
 `;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #85

## 📝 작업 내용

Home.tsx에서 `margin-bottom: 40px;`를 삭제

## 💬 리뷰 요구사항