### PR TITLE
API 요청에 `/api` prefix가 붙도록 수정

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -11,7 +11,7 @@ class Client {
 
   async fetch<TData>(input: RequestInfo | URL, init?: RequestInit): Promise<TData> {
     try {
-      const response = await fetch(input, {
+      const response = await fetch(`/api${input}`, {
         ...init,
         headers: {
           ...init?.headers,

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -3,7 +3,7 @@ import { cafes } from '../data/mockData';
 
 export const handlers = [
   // 카페 조회
-  rest.get('/cafes', (req, res, ctx) => {
+  rest.get('/api/cafes', (req, res, ctx) => {
     const page = Number(req.url.searchParams.get('page') || 1);
 
     return res(
@@ -19,7 +19,7 @@ export const handlers = [
   }),
 
   // 좋아요 추가
-  rest.post('/cafes/:cafe_id/likes', (req, res, ctx) => {
+  rest.post('/api/cafes/:cafe_id/likes', (req, res, ctx) => {
     const { cafeId } = req.params;
     const updatedCafes = cafes.map((cafe) => {
       if (cafe.id === Number(cafeId)) {
@@ -31,7 +31,7 @@ export const handlers = [
   }),
 
   // 좋아요 취소
-  rest.delete('/cafes/:cafe_id/likes', (req, res, ctx) => {
+  rest.delete('/api/cafes/:cafe_id/likes', (req, res, ctx) => {
     const { cafeId } = req.params;
     const updatedCafes = cafes.map((cafe) => {
       if (cafe.id === Number(cafeId) && cafe.likeCount > 0) {
@@ -43,7 +43,7 @@ export const handlers = [
   }),
 
   // 인증 코드를 accessToken으로 교환
-  rest.post('/auth/kakao', async (req, res, ctx) => {
+  rest.post('/api/auth/kakao', async (req, res, ctx) => {
     const code = req.url.searchParams.get('code');
     if ((code?.length ?? 0) <= 0) {
       return res(

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -9,7 +9,7 @@ const Login = () => {
         <Logo fontSize="7xl" />
       </LogoContainer>
       <ButtonContainer>
-        <a href="/auth/kakao?code=1234">
+        <a href="/api/auth/kakao?code=1234">
           <KakaoLoginButton>
             <LoginButton $color="yellow" $border="none">
               <ButtonContent>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #60 

## 📝 작업 내용
* 백엔드와 프론트엔드가 동일한 origin을 사용하기 때문에 path를 구분할 필요가 있음
* 요청이 `/api`로 시작하는 경우 백엔드로, 그 외에는 프론트엔드에서 처리
* 이 PR은 해당 내용을 모킹과 api client에 반영함

## 💬 리뷰 요구사항