### PR TITLE
백엔드 Dockerfile 추가 및 docker-compose.yml service 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ server/.nb-gradle/
 
 ### VS Code ###
 server/.vscode/
+
+.env

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+AUTH_KEY=example-secret-key
+AUTH_GOOGLE_CLIENTID=example-google-clientid
+AUTH_GOOGLE_CLIENTSECRET=example-google-clientsecret
+AUTH_KAKAO_CLIENTID=example-kakao-clientid
+AUTH_KAKAO_CLIENTSECRET=example-kakao-clientsecret

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,22 @@
+FROM gradle:8.1.1-jdk as build
+
+WORKDIR /work
+
+# 빌드 스테이지에 소스 코드 파일들 추가
+COPY src ./src
+COPY build.gradle .
+COPY settings.gradle .
+
+# 테스트를 제외하고 빌드 진행
+RUN gradle build -x test
+RUN mv /work/build/libs/*[!-plain].jar ./app.jar
+
+
+FROM eclipse-temurin:17-jre
+
+COPY --from=build /work/app.jar .
+
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh ./wait-for-it.sh
+RUN chmod +x ./wait-for-it.sh
+
+CMD ./wait-for-it.sh -t 0 mysql:3306 -- java -jar ./app.jar

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,5 +1,30 @@
 version: "3.8"
 services:
+  server:
+    build: .
+    restart: always
+    ports:
+      - 8080:8080
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/yozm-cafe?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+      SPRING_AUTH_KEY: ${AUTH_KEY?"AUTH_KEY should not empty"}
+
+      SPRING_AUTH_GOOGLE_TOKENURI: https://www.googleapis.com/oauth2/v4/token
+      SPRING_AUTH_GOOGLE_AUTHURI: https://accounts.google.com/o/oauth2/v2/auth
+      SPRING_AUTH_GOOGLE_REDIRECTURI: http://localhost:3000/auth/google
+      SPRING_AUTH_GOOGLE_SCOPE: https%3A//www.googleapis.com/auth/userinfo.profile
+      SPRING_AUTH_GOOGLE_CLIENTID: ${AUTH_GOOGLE_CLIENTID?"AUTH_GOOGLE_CLIENTID should not empty"}
+      SPRING_AUTH_GOOGLE_CLIENTSECRET: ${AUTH_GOOGLE_CLIENTSECRET?"AUTH_GOOGLE_CLIENTSECRET should not empty"}
+
+      SPRING_AUTH_KAKAO_TOKENURI: https://kauth.kakao.com/oauth/token
+      SPRING_AUTH_KAKAO_AUTHURI: https://kauth.kakao.com/oauth/authorize
+      SPRING_AUTH_KAKAO_REDIRECTURI: http://localhost:3000/auth/kakao
+      SPRING_AUTH_KAKAO_SCOPE: openid,profile_nickname,profile_image
+      SPRING_AUTH_KAKAO_CLIENTID: ${AUTH_KAKAO_CLIENTID?"AUTH_KAKAO_CLIENTID should not empty"}
+      SPRING_AUTH_KAKAO_CLIENTSECRET: ${AUTH_KAKAO_CLIENTSECRET?"AUTH_KAKAO_CLIENTSECRET should not empty"}
+
   mysql:
     platform: linux/arm64/v8
     image: library/mysql:8.0.33


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #124 

## 📝 작업 내용
* 프론트엔드에서 백엔드 컨테이너를 띄우고 연동 작업을 하기 위해 dockerize를 하였습니다.
* Dockerfile을 추가하였습니다. 멀티-스테이지 빌드를 적용하였습니다.
* docker-compose.yml에 백엔드를 추가하였습니다. 민감한 정보는 .env 파일에 작성해주세요.
* wait-for-it.sh 를 적용하여 mysql DB가 켜지는 것을 기다린 후 백엔드 서버가 켜지도록 하였습니다.

### .env 작성 예시
docker-compose.yml 이 있는 디렉토리에 .env 파일을 생성하고 아래와 같은 형식으로 작성하시면 됩니다.
```
AUTH_KEY=
AUTH_GOOGLE_CLIENTID=
AUTH_GOOGLE_CLIENTSECRET=
AUTH_KAKAO_CLIENTID=
AUTH_KAKAO_CLIENTSECRET=
```

## 💬 리뷰 요구사항
잘 동작하는지 확인해주시면 감사하겠습니다.