### PR TITLE
webpack typescript 타입 체킹 적용 (fork-ts-checker-webpack-plugin)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-storybook": "^0.6.12",
+    "fork-ts-checker-webpack-plugin": "^8.0.0",
     "html-webpack-plugin": "^5.5.3",
     "msw": "^1.2.2",
     "postcss-styled-syntax": "^0.4.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,12 +1,17 @@
 import CopyPlugin from 'copy-webpack-plugin';
 import DotenvWebpackPlugin from 'dotenv-webpack';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 const API_URL = process.env.API_URL ?? 'http://localhost:8080';
 
 /** @type {import('webpack').Configuration} */
 export default {
   mode: 'development',
+  // https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#installation
+  context: dirname(fileURLToPath(import.meta.url)),
   entry: './src/index',
   output: {
     filename: 'bundle.js',
@@ -35,6 +40,7 @@ export default {
     new CopyPlugin({
       patterns: [{ from: 'public', to: '' }],
     }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
   devServer: {
     hot: true,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5778,6 +5778,24 @@ fork-ts-checker-webpack-plugin@^7.2.8:
     semver "^7.3.5"
     tapable "^2.2.1"
 
+fork-ts-checker-webpack-plugin@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz#dae45dfe7298aa5d553e2580096ced79b6179504"
+  integrity sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    chalk "^4.1.2"
+    chokidar "^3.5.3"
+    cosmiconfig "^7.0.1"
+    deepmerge "^4.2.2"
+    fs-extra "^10.0.0"
+    memfs "^3.4.1"
+    minimatch "^3.0.4"
+    node-abort-controller "^3.0.1"
+    schema-utils "^3.1.1"
+    semver "^7.3.5"
+    tapable "^2.2.1"
+
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #127 

## 📝 작업 내용
![image](https://github.com/woowacourse-teams/2023-yozm-cafe/assets/20203944/10c45044-257b-4e8d-ab75-0a5978312be8)

* webpack dev server 혹은 build 실행 시 typescript type 체킹이 동작하도록 수정하였음
* 개발 중 타입 오류를 사전에 빠르게 감지할 수 있음
* CI/CD 파이프라인에서 타입 검사 결과가 올바르지 않을 시 파이프라인을 중단할 수 있음

## 💬 리뷰 요구사항
