### PR TITLE
백엔드 로그아웃 기능 구현

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
     public ResponseEntity<TokenResponse> refreshToken(final HttpServletRequest request,
                                                       final HttpServletResponse response,
                                                       @CookieValue(name = REFRESH_TOKEN) final String refreshToken) {
-        final String accessToken = request.getHeader(AUTHORIZATION);
+        final String accessToken = request.getHeader(AUTHORIZATION).replace("Bearer ","");
         final TokenResponse tokenResponse = authService.refreshAccessToken(accessToken, refreshToken);
         setRefreshTokenCookie(response);
         return ResponseEntity.ok(tokenResponse);

--- a/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
@@ -15,6 +15,7 @@ public class AuthController {
 
     private static final String REFRESH_TOKEN = "refreshToken";
     private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
 
     private final AuthService authService;
 
@@ -43,7 +44,7 @@ public class AuthController {
     public ResponseEntity<TokenResponse> refreshToken(final HttpServletRequest request,
                                                       final HttpServletResponse response,
                                                       @CookieValue(name = REFRESH_TOKEN) final String refreshToken) {
-        final String accessToken = request.getHeader(AUTHORIZATION).replace("Bearer ","");
+        final String accessToken = request.getHeader(AUTHORIZATION).replace(BEARER,"");
         final TokenResponse tokenResponse = authService.refreshAccessToken(accessToken, refreshToken);
         setRefreshTokenCookie(response);
         return ResponseEntity.ok(tokenResponse);

--- a/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
@@ -47,12 +47,21 @@ public class AuthController {
         final TokenResponse tokenResponse = authService.refreshAccessToken(accessToken, refreshToken);
         setRefreshTokenCookie(response);
         return ResponseEntity.ok(tokenResponse);
-    }   
+    }
 
     @GetMapping("/{providerName}")
     public String redirectAuthorizationUri(@PathVariable("providerName") final OAuthProvider oAuthProvider) {
         final String authUri = authService.getAuthorizationUri(oAuthProvider);
 
         return "redirect:" + authUri;
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> logout(final HttpServletResponse response) {
+        final Cookie cookie = new Cookie(REFRESH_TOKEN, null);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/controller/auth/OAuthProvider.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/auth/OAuthProvider.java
@@ -1,5 +1,6 @@
 package com.project.yozmcafe.controller.auth;
 
+import com.project.yozmcafe.domain.member.MemberInfo;
 import com.project.yozmcafe.service.auth.GoogleOAuthClient;
 import com.project.yozmcafe.service.auth.KakaoOAuthClient;
 import com.project.yozmcafe.service.auth.OAuthClient;
@@ -30,7 +31,7 @@ public enum OAuthProvider {
         return oAuthClient.getUserInfo(code);
     }
 
-    public String getAuthorizationUrl(){
+    public String getAuthorizationUrl() {
         return oAuthClient.getAuthorizationUrl();
     }
 

--- a/server/src/main/java/com/project/yozmcafe/domain/auth/token/OAuthToken.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/auth/token/OAuthToken.java
@@ -1,7 +1,7 @@
 package com.project.yozmcafe.domain.auth.token;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.project.yozmcafe.controller.auth.MemberInfo;
+import com.project.yozmcafe.domain.member.MemberInfo;
 
 import java.util.Arrays;
 import java.util.Base64;

--- a/server/src/main/java/com/project/yozmcafe/domain/member/MemberInfo.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/MemberInfo.java
@@ -1,6 +1,4 @@
-package com.project.yozmcafe.controller.auth;
-
-import com.project.yozmcafe.domain.member.Member;
+package com.project.yozmcafe.domain.member;
 
 public record MemberInfo(String openId, String name, String image) {
 

--- a/server/src/main/java/com/project/yozmcafe/service/auth/AuthService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/auth/AuthService.java
@@ -1,9 +1,9 @@
 package com.project.yozmcafe.service.auth;
 
-import com.project.yozmcafe.controller.auth.MemberInfo;
 import com.project.yozmcafe.controller.auth.OAuthProvider;
 import com.project.yozmcafe.controller.dto.TokenResponse;
 import com.project.yozmcafe.domain.member.Member;
+import com.project.yozmcafe.domain.member.MemberInfo;
 import com.project.yozmcafe.domain.member.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/server/src/main/java/com/project/yozmcafe/service/auth/OAuthClient.java
+++ b/server/src/main/java/com/project/yozmcafe/service/auth/OAuthClient.java
@@ -1,7 +1,7 @@
 package com.project.yozmcafe.service.auth;
 
-import com.project.yozmcafe.controller.auth.MemberInfo;
 import com.project.yozmcafe.domain.auth.token.OAuthToken;
+import com.project.yozmcafe.domain.member.MemberInfo;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;

--- a/server/src/test/java/com/project/yozmcafe/domain/auth/token/OAuthTokenTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/auth/token/OAuthTokenTest.java
@@ -1,6 +1,6 @@
 package com.project.yozmcafe.domain.auth.token;
 
-import com.project.yozmcafe.controller.auth.MemberInfo;
+import com.project.yozmcafe.domain.member.MemberInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/server/src/test/java/com/project/yozmcafe/service/MemberServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/MemberServiceTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@Transactional
 class MemberServiceTest {
 
     @Autowired

--- a/server/src/test/java/com/project/yozmcafe/service/auth/AuthServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/auth/AuthServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.anyString;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.doReturn;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest
+@Transactional
 class AuthServiceTest {
 
     @SpyBean

--- a/server/src/test/java/com/project/yozmcafe/service/auth/AuthServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/auth/AuthServiceTest.java
@@ -1,8 +1,8 @@
 package com.project.yozmcafe.service.auth;
 
-import com.project.yozmcafe.controller.auth.MemberInfo;
 import com.project.yozmcafe.controller.auth.OAuthProvider;
 import com.project.yozmcafe.domain.member.Member;
+import com.project.yozmcafe.domain.member.MemberInfo;
 import com.project.yozmcafe.domain.member.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/server/src/test/java/com/project/yozmcafe/util/AcceptanceContext.java
+++ b/server/src/test/java/com/project/yozmcafe/util/AcceptanceContext.java
@@ -1,14 +1,14 @@
 package com.project.yozmcafe.util;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.springframework.stereotype.Component;
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.http.Cookie;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class AcceptanceContext {
@@ -120,6 +120,14 @@ public class AcceptanceContext {
                 .given().log().all()
                 .body(data).contentType(ContentType.JSON)
                 .auth().oauth2(accessToken);
+        response = request.delete(path);
+        response.then().log().all();
+    }
+
+    public void invokeHttpDeleteWithCookie(String path, Cookie cookie) {
+        request = RestAssured
+                .given().log().all()
+                .cookie(cookie);
         response = request.delete(path);
         response.then().log().all();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- closed #113

## 📝 작업 내용
- MemberInfo VO가 controller에 있었는데 domain으로 이동
- 롤백 안되던 @SpringBootTest에 @Transactional 추가
- 로그아웃 컨트롤러 추가
- 리프레시 토큰 제거 테스트
  - AcceptanceContext에 `invokeHttpDeleteWithCookie` 메서드 추가

