### PR TITLE
`/cafes` API의 응답 데이터가 없을 때 fetch가 무한으로 일어나고 있는 오류 수정

### DIFF
--- a/client/src/hooks/useCafes.ts
+++ b/client/src/hooks/useCafes.ts
@@ -22,7 +22,7 @@ const useCafes = () => {
   const queryResult = useInfiniteQuery({
     queryKey: [''],
     queryFn: ({ pageParam = 1 }) => client.getCafes(pageParam).then((cafes) => ({ cafes, page: pageParam })),
-    getNextPageParam: (lastPage) => lastPage.page + 1,
+    getNextPageParam: (lastPage) => (lastPage.cafes.length > 0 ? lastPage.page + 1 : undefined),
   });
   return {
     ...queryResult,

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import useCafes from '../hooks/useCafes';
 const PREFETCH_OFFSET = 2;
 
 const Home = () => {
-  const { isFetching, cafes, fetchNextPage } = useCafes();
+  const { cafes, fetchNextPage, isFetching, hasNextPage } = useCafes();
   const [activeCafe, setActiveCafe] = useState(cafes[0]);
 
   // https://github.com/woowacourse-teams/2023-yozm-cafe/pull/49#discussion_r1264872201
@@ -25,7 +25,9 @@ const Home = () => {
     });
   }, [cafes]);
 
-  if (!isFetching && cafes.findIndex((cafe) => cafe.id === activeCafe.id) + PREFETCH_OFFSET >= cafes.length) {
+  const shouldFetch =
+    hasNextPage && isFetching && cafes.findIndex((cafe) => cafe.id === activeCafe.id) + PREFETCH_OFFSET >= cafes.length;
+  if (shouldFetch) {
     fetchNextPage();
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #125 

## 📝 작업 내용
* 메인 화면에서 `/cafes` API를 호출하는데, 응답이 비어있는 배열(`[]`)인 경우 fetch가 무한으로 발생하고 있었음
* 이 오류를 수정하였음

## 💬 리뷰 요구사항