### PR TITLE
로그인 버튼에서 프로필 버튼으로 전환 시 디자인 수정

### DIFF
--- a/client/src/components/Button.stories.tsx
+++ b/client/src/components/Button.stories.tsx
@@ -13,6 +13,6 @@ export default meta;
 export const Default: Story = {
   args: {
     children: '버튼',
-    fullWidth: true,
+    $fullWidth: true,
   },
 };

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -3,13 +3,13 @@ import styled, { css } from 'styled-components';
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'default' | 'outlined' | 'disabled';
-  fullWidth?: boolean;
-  fullHeight?: boolean;
+  $fullWidth?: boolean;
+  $fullHeight?: boolean;
 };
 
-const Button = ({ children, variant = 'default', fullWidth = false, fullHeight = false, ...rest }: ButtonProps) => {
+const Button = ({ children, variant = 'default', $fullWidth = false, $fullHeight = false, ...rest }: ButtonProps) => {
   return (
-    <Container variant={variant} fullWidth={fullWidth} fullHeight={fullHeight} {...rest}>
+    <Container variant={variant} $fullWidth={$fullWidth} $fullHeight={$fullHeight} {...rest}>
       {children}
     </Container>
   );
@@ -45,6 +45,6 @@ const Container = styled.button<ButtonProps>`
 
   border-radius: 40px;
   ${(props) => ButtonVariants[props.variant || 'default']}
-  ${(props) => props.fullWidth && 'width: 100%;'}
-  ${(props) => props.fullHeight && 'height: 100%;'}
+  ${(props) => props.$fullWidth && 'width: 100%;'}
+  ${(props) => props.$fullHeight && 'height: 100%;'}
 `;

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import useUser from '../hooks/useUser';
 import Button from './Button';
@@ -8,6 +8,7 @@ import Logo from './Logo';
 
 const Navbar = () => {
   const { data: user } = useUser();
+  const navigate = useNavigate();
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
   const openLoginModal = () => {
@@ -18,6 +19,10 @@ const Navbar = () => {
     setIsLoginModalOpen(false);
   };
 
+  const handleProfileClick = () => {
+    navigate('/my-profile');
+  };
+
   return (
     <Container>
       <LogoContainer to="/">
@@ -25,9 +30,11 @@ const Navbar = () => {
       </LogoContainer>
       <ButtonContainer>
         {user ? (
-          <ProfileImage src={user.imageUrl} alt="Profile" />
+          <Button variant="outlined" $fullWidth={true} $fullHeight={true} onClick={handleProfileClick}>
+            프로필
+          </Button>
         ) : (
-          <Button fullWidth={true} fullHeight={true} onClick={openLoginModal}>
+          <Button $fullWidth={true} $fullHeight={true} onClick={openLoginModal}>
             로그인
           </Button>
         )}
@@ -50,14 +57,10 @@ const Container = styled.nav`
 `;
 
 const ButtonContainer = styled.div`
-  width: 25%;
+  flex: 3;
 `;
 
 const LogoContainer = styled(Link)`
+  flex: 7;
   text-decoration: none;
-`;
-
-const ProfileImage = styled.img`
-  height: 100%;
-  border-radius: 100%;
 `;

--- a/client/src/pages/MyProfile.tsx
+++ b/client/src/pages/MyProfile.tsx
@@ -25,10 +25,10 @@ const MyProfile = () => {
       <ProfileInfo userImage={user.imageUrl} userName={user.name} />
       <ButtonContainer>
         <EditButtonContainer>
-          <Button fullWidth>프로필 수정하기</Button>
+          <Button $fullWidth>프로필 수정하기</Button>
         </EditButtonContainer>
         <LogOutButton>
-          <Button variant="outlined" fullWidth onClick={handleLogout}>
+          <Button variant="outlined" $fullWidth onClick={handleLogout}>
             로그아웃
           </Button>
         </LogOutButton>

--- a/client/src/pages/MyProfile.tsx
+++ b/client/src/pages/MyProfile.tsx
@@ -28,7 +28,7 @@ const MyProfile = () => {
           <Button $fullWidth>프로필 수정하기</Button>
         </EditButtonContainer>
         <LogOutButton>
-          <Button variant="outlined" $fullWidth onClick={handleLogout}>
+          <Button variant="disabled" $fullWidth onClick={handleLogout}>
             로그아웃
           </Button>
         </LogOutButton>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #198 

## 📝 작업 내용

- 로그인 버튼에서 프로필 버튼으로 전환 시 디자인 수정
- 로그아웃 색상 변경
- `fullWidth`와 `fullHeight`가 DOM 요소로 렌더링이 되지 않도록 달러 기호 추가

## 💬 리뷰 요구사항
