### PR TITLE
홈화면에서 모달, 공유, 좋아요 아이콘의 크기와 모양을 수정한다.

### DIFF
--- a/client/src/components/CafeActionBar.tsx
+++ b/client/src/components/CafeActionBar.tsx
@@ -17,7 +17,6 @@ const CafeActionBar = () => {
       <Action>
         <LikeButton likeCount={likeCount} active={isLiked} onChange={handleLikeCountIncrease} />
       </Action>
-
       <Action>
         <ShareButton />
       </Action>
@@ -30,13 +29,14 @@ export default CafeActionBar;
 const Container = styled.aside`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.space[6]};
+  gap: ${({ theme }) => theme.space[3]};
   align-self: flex-end;
 
-  padding-right: ${({ theme }) => theme.space[3]};
+  padding-right: ${({ theme }) => theme.space[5]};
 `;
 
 const Action = styled.button`
+  padding: 0;
   color: white;
   background: none;
   border: none;

--- a/client/src/components/CafeCard.tsx
+++ b/client/src/components/CafeCard.tsx
@@ -59,5 +59,5 @@ const Aside = styled.div`
   position: relative;
   display: flex;
   flex-direction: column-reverse;
-  gap: ${({ theme }) => theme.space[20]};
+  gap: ${({ theme }) => theme.space[5]};
 `;

--- a/client/src/components/CafeInfoModal.tsx
+++ b/client/src/components/CafeInfoModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { RiArrowUpDoubleLine } from 'react-icons/ri';
+import { BiSolidInfoCircle } from 'react-icons/bi';
 import { SlLocationPin } from 'react-icons/sl';
 import { styled } from 'styled-components';
 
@@ -21,11 +21,17 @@ const CafeInfoModal = ({ title, address, content }: CafeInfoModalProps) => {
       </Address>
       <Modal className={isOpen ? 'active' : ''} onClick={() => setIsOpen(!isOpen)}>
         {!isOpen && (
-          <ArrowDownContainer>
-            <ArrowUpIcon />
-          </ArrowDownContainer>
+          <MoreInfoContainer>
+            <MoreInfoContent>
+              <SolidInfoCircleIcon />
+              <Text>더보기</Text>
+            </MoreInfoContent>
+          </MoreInfoContainer>
         )}
-        <Content>{content}</Content>
+        <Content>
+          {title}
+          {content}
+        </Content>
       </Modal>
     </Container>
   );
@@ -40,11 +46,28 @@ const Container = styled.div`
 
   height: 80px;
   max-height: 80px;
-  margin-left: ${({ theme }) => theme.space[4]};
 `;
 
-const ArrowUpIcon = styled(RiArrowUpDoubleLine)`
-  font-size: ${({ theme }) => theme.fontSize['3xl']};
+const Text = styled.span`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: ${({ theme }) => theme.color.white};
+`;
+
+const MoreInfoContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const MoreInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  padding-right: ${({ theme }) => theme.space[5]};
+`;
+
+const SolidInfoCircleIcon = styled(BiSolidInfoCircle)`
+  font-size: ${({ theme }) => theme.fontSize['4xl']};
   color: ${({ theme }) => theme.color.white};
 `;
 
@@ -53,19 +76,17 @@ const LocationPinIcon = styled(SlLocationPin)`
   font-size: ${({ theme }) => theme.fontSize.sm};
 `;
 
-const ArrowDownContainer = styled.div`
-  display: flex;
-  justify-content: center;
-`;
-
 const Title = styled.h1`
   padding-bottom: ${({ theme }) => theme.space['1.5']};
+  padding-left: ${({ theme }) => theme.space[3]};
+
   font-size: ${({ theme }) => theme.fontSize['3xl']};
   font-weight: bolder;
   color: ${({ theme }) => theme.color.white};
 `;
 
 const Address = styled.h2`
+  padding-left: ${({ theme }) => theme.space[3]};
   font-size: ${({ theme }) => theme.fontSize.lg};
   color: ${({ theme }) => theme.color.white};
 `;
@@ -76,28 +97,16 @@ const Content = styled.p`
 `;
 
 const Modal = styled.main`
-  will-change: transform;
-
   position: absolute;
-  bottom: 0;
-
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 8px;
-
   width: 100%;
-  height: 90px;
-  padding: ${({ theme }) => theme.space[4]};
 
-  transition: all 0.3s;
-
-  &:not(.active):hover {
+  &:not(.active) {
     cursor: pointer;
-    height: 100px;
+    height: 80px;
   }
-
   &.active {
+    cursor: pointer;
+
     right: 0;
     bottom: 0;
     left: 0;
@@ -107,11 +116,11 @@ const Modal = styled.main`
     opacity: 1;
     background: ${({ theme }) => theme.color.white};
     backdrop-filter: none;
+    border-radius: 20px 20px 0 0;
   }
 
   & > ${Content} {
     opacity: 0;
-    transition: opacity 0.2s;
   }
 
   &.active > ${Content} {

--- a/client/src/components/LikeButton.tsx
+++ b/client/src/components/LikeButton.tsx
@@ -22,7 +22,7 @@ export default LikeButton;
 
 const HeartIcon = styled(PiHeartFill)<{ $active: boolean }>`
   cursor: pointer;
-  font-size: ${({ theme }) => theme.fontSize['5xl']};
+  font-size: ${({ theme }) => theme.fontSize['4xl']};
   color: ${({ theme, $active }) => ($active ? theme.color.primary : theme.color.white)};
 `;
 

--- a/client/src/components/ShareButton.tsx
+++ b/client/src/components/ShareButton.tsx
@@ -10,7 +10,7 @@ const ShareButton = () => {
   return (
     <Container>
       <Button onClick={handleClick} />
-      <Text>공유하기</Text>
+      <Text>공유</Text>
     </Container>
   );
 };
@@ -25,7 +25,7 @@ const Container = styled.aside`
 
 const Button = styled(PiShareFatFill)`
   cursor: pointer;
-  font-size: ${({ theme }) => theme.fontSize['5xl']};
+  font-size: ${({ theme }) => theme.fontSize['4xl']};
 `;
 
 const Text = styled.span`


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #200 

## 📝 작업 내용

- [CafeActionBar 컴포넌트의 gap과 padding 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/cd764b789d20142d76e294ebbb428e8bc1e1b218)
- [CafeCard 컴포넌트의 gap 크기 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/aff7c5c3c8acf9cbfc7bdb077ce3b9451bdea1be)
- [CafeInfoModal 컴포넌트의 모양 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/f74f7cd4dddaf47c6cd809519ce3383e3531a8b2)
- [LikeButton 컴포넌트의 크기 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/89847079297fc523d6577bad7455b6e2112515d7)
- [공유하기 아이콘 크기와 텍스트 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/03bdee13d62092f79f753b3e7f33b26d3f4b2b6f)

## 💬 리뷰 요구사항