### PR TITLE
createGlobalStyle에서 사용하면 안되는 @import 구문을 제거한다.

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -2,14 +2,14 @@ import { ButtonHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: 'default' | 'outlined' | 'disabled';
+  $variant?: 'default' | 'outlined' | 'disabled';
   $fullWidth?: boolean;
   $fullHeight?: boolean;
 };
 
-const Button = ({ children, variant = 'default', $fullWidth = false, $fullHeight = false, ...rest }: ButtonProps) => {
+const Button = ({ children, $variant = 'default', $fullWidth = false, $fullHeight = false, ...rest }: ButtonProps) => {
   return (
-    <Container variant={variant} $fullWidth={$fullWidth} $fullHeight={$fullHeight} {...rest}>
+    <Container $variant={$variant} $fullWidth={$fullWidth} $fullHeight={$fullHeight} {...rest}>
       {children}
     </Container>
   );
@@ -44,7 +44,7 @@ const Container = styled.button<ButtonProps>`
   font-weight: 500;
 
   border-radius: 40px;
-  ${(props) => ButtonVariants[props.variant || 'default']}
+  ${(props) => ButtonVariants[props.$variant || 'default']}
   ${(props) => props.$fullWidth && 'width: 100%;'}
   ${(props) => props.$fullHeight && 'height: 100%;'}
 `;

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -30,7 +30,7 @@ const Navbar = () => {
       </LogoContainer>
       <ButtonContainer>
         {user ? (
-          <Button variant="outlined" $fullWidth={true} $fullHeight={true} onClick={handleProfileClick}>
+          <Button $variant="outlined" $fullWidth={true} $fullHeight={true} onClick={handleProfileClick}>
             프로필
           </Button>
         ) : (

--- a/client/src/pages/MyProfile.tsx
+++ b/client/src/pages/MyProfile.tsx
@@ -40,7 +40,7 @@ const MyProfile = () => {
           <Button $fullWidth>프로필 수정하기</Button>
         </EditButtonContainer>
         <LogOutButton>
-          <Button variant="disabled" $fullWidth onClick={handleLogout}>
+          <Button $variant="disabled" $fullWidth onClick={handleLogout}>
             로그아웃
           </Button>
         </LogOutButton>

--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -6,7 +6,7 @@ const GlobalStyle = createGlobalStyle`
     font-weight: 400;
     font-style: normal;
     src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-}
+  }
 
   @font-face {
     font-family: 'BMJUA';

--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -1,7 +1,12 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
-  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+  @font-face {
+    font-family: 'Pretendard-Regular';
+    font-weight: 400;
+    font-style: normal;
+    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+}
 
   @font-face {
     font-family: 'BMJUA';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #208 

## 📝 작업 내용

- 프리텐다드의 @import를 @font-face로 수정
- Button 컴포넌트의 variant가 DOM 요소로 렌더링 안되게 달러 사인 추가

## 💬 리뷰 요구사항
