### PR TITLE
로그인 상태가 영구적으로 저장되도록 구현

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -23,8 +23,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
     if (!accessToken) return null;
 
     const [header, payload, verifySignature] = accessToken.split('.');
-    const identity = JSON.parse(window.atob(payload)) as Identity;
-    return identity;
+    return JSON.parse(window.atob(payload)) as Identity;
   }, [accessToken]);
 
   const contextValue = useMemo(

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -1,9 +1,12 @@
-import { Dispatch, PropsWithChildren, createContext, useMemo, useState } from 'react';
+import { Dispatch, PropsWithChildren, createContext, useMemo } from 'react';
+import client from '../client';
+import usePersistedState from '../hooks/usePersistedState';
 import { Identity } from '../types';
 
 type AuthContextValue = {
+  accessToken: string | null;
+  setAccessToken: Dispatch<string | null>;
   identity: Identity | null;
-  setIdentity: Dispatch<Identity | null>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -12,14 +15,25 @@ type AuthProviderProps = PropsWithChildren;
 
 export const AuthProvider = (props: AuthProviderProps) => {
   const { children } = props;
-  const [identity, setIdentity] = useState<Identity | null>(null);
+  const [accessToken, setAccessToken] = usePersistedState<string | null>('accessToken', null);
+
+  const identity = useMemo(() => {
+    client.setAccessToken(accessToken);
+
+    if (!accessToken) return null;
+
+    const [header, payload, verifySignature] = accessToken.split('.');
+    const identity = JSON.parse(window.atob(payload)) as Identity;
+    return identity;
+  }, [accessToken]);
 
   const contextValue = useMemo(
     () => ({
+      accessToken,
+      setAccessToken,
       identity,
-      setIdentity,
     }),
-    [identity],
+    [accessToken, setAccessToken, identity],
   );
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;

--- a/client/src/hooks/usePersistedState.ts
+++ b/client/src/hooks/usePersistedState.ts
@@ -1,0 +1,34 @@
+import { Dispatch, useEffect, useState } from 'react';
+
+/**
+ * useState와 localStorage가 결합된 훅입니다. 영구 저장되는 상태를 이용할 수 있습니다.
+ * 상태 값은 `JSON.stringify` 및 `JSON.parse` 가능한 값으로 사용하여야 합니다.
+ *
+ * @example
+ * const Example = () => {
+ *   const [accessToken, setAccessToken] = usePersistedState(null);
+ *
+ *   const onLogin = () => {
+ *     login().then((response) => setAccessToken(response.data.accessToken));
+ *   }
+ *
+ *   return (
+ *     // ...
+ *   )
+ * }
+ */
+const usePersistedState = <T extends string | number | object | null | undefined>(
+  key: string,
+  initialValue: T,
+): [T, Dispatch<T>] => {
+  const serializedItem = localStorage.getItem(key);
+  const [state, setState] = useState<T>(serializedItem ? JSON.parse(serializedItem) : initialValue);
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [state]);
+
+  return [state, setState];
+};
+
+export default usePersistedState;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #207 

## 📝 작업 내용
* 상태를 영구 저장해주는 커스텀 훅 `usePersistedState` 구현
* `useAuth` 의 `identity` 계산, `client` 객체와 `accessToken` 동기화하는 책임을 `AuthProvider` 에서 수행하도록 함

## 💬 리뷰 요구사항
작지도 않지만 크지도 않은 변동 사항이 있으니 참고 부탁드립니다.