### PR TITLE
좋아요한 카페 최신 순으로 출력 되도록 수정

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/domain/member/MemberRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/MemberRepository.java
@@ -14,6 +14,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findById(String id);
 
-    @Query("SELECT likedCafes FROM Member m JOIN m.likedCafes likedCafes WHERE m.id = :memberId")
+    @Query("SELECT likedCafes FROM Member m JOIN m.likedCafes likedCafes WHERE m.id = :memberId ORDER BY likedCafes.id DESC")
     Slice<LikedCafe> findLikedCafesByMemberId(@Param("memberId") final String memberId, final Pageable pageable);
 }

--- a/server/src/test/java/com/project/yozmcafe/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/MemberControllerTest.java
@@ -100,8 +100,8 @@ class MemberControllerTest {
 
         //then
         assertAll(
-                () -> assertThat(response.jsonPath().getLong("[0].cafeId")).isEqualTo(savedCafe1.getId()),
-                () -> assertThat(response2.jsonPath().getLong("[0].cafeId")).isEqualTo(savedCafe2.getId())
+                () -> assertThat(response.jsonPath().getLong("[0].cafeId")).isEqualTo(savedCafe2.getId()),
+                () -> assertThat(response2.jsonPath().getLong("[0].cafeId")).isEqualTo(savedCafe1.getId())
         );
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #231

## 📝 작업 내용

> 원래 좋아요한 카페 목록을 조회할 때 좋아요 누른 카페 순서대로 출력이 되었는데 이를 수정하여 최신 좋아요 카페부터 출력하도록 수정하였습니다.

## 💬 리뷰 요구사항