### PR TITLE
좋아요 아이콘과 더보기 아이콘의 간격이 안맞는 부분을 수정한다.

### DIFF
--- a/client/src/components/CafeActionBar.tsx
+++ b/client/src/components/CafeActionBar.tsx
@@ -40,7 +40,7 @@ const Container = styled.aside`
   display: flex;
   flex-direction: column;
   align-self: flex-end;
-  padding-right: ${({ theme }) => theme.space[4]};
+  padding-right: ${({ theme }) => theme.space[3]};
 `;
 
 const Action = styled.button`

--- a/client/src/styles/ResetStyle.ts
+++ b/client/src/styles/ResetStyle.ts
@@ -47,6 +47,7 @@ const ResetStyle = createGlobalStyle`
   input,
   select {
     margin: 0;
+    padding: 0;
   }
 
   button {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #238 

## 📝 작업 내용

- 버튼 태그의 padding을 0으로 수정
- 좋아요 버튼과 더보기 버튼의 padding를 동일하게 수정

## 💬 리뷰 요구사항