### PR TITLE
custom Exception 적용

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/controller/GlobalControllerAdvice.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/GlobalControllerAdvice.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import com.project.yozmcafe.exception.BadRequestException;
 import com.project.yozmcafe.exception.ErrorResponse;
-import com.project.yozmcafe.exception.InternalServerException;
+import com.project.yozmcafe.exception.OAuthException;
 import com.project.yozmcafe.exception.TokenException;
 
 @ControllerAdvice
@@ -30,8 +30,8 @@ public class GlobalControllerAdvice {
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handle(final InternalServerException e) {
-        logger.error("Internal Server Error: {}", e.getErrorResponse());
+    public ResponseEntity<ErrorResponse> handle(final OAuthException e) {
+        logger.error("OAuth exception: {}", e.getErrorResponse());
         return ResponseEntity.internalServerError().body(e.getErrorResponse());
     }
 

--- a/server/src/main/java/com/project/yozmcafe/controller/GlobalControllerAdvice.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/GlobalControllerAdvice.java
@@ -1,14 +1,16 @@
 package com.project.yozmcafe.controller;
 
-import com.project.yozmcafe.exception.BadRequestException;
-import com.project.yozmcafe.exception.ErrorResponse;
-import com.project.yozmcafe.exception.TokenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.project.yozmcafe.exception.BadRequestException;
+import com.project.yozmcafe.exception.ErrorResponse;
+import com.project.yozmcafe.exception.InternalServerException;
+import com.project.yozmcafe.exception.TokenException;
 
 @ControllerAdvice
 public class GlobalControllerAdvice {
@@ -25,6 +27,12 @@ public class GlobalControllerAdvice {
     public ResponseEntity<ErrorResponse> handle(final BadRequestException e) {
         logger.info("Bad Request: {}", e.getErrorResponse());
         return ResponseEntity.badRequest().body(e.getErrorResponse());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handle(final InternalServerException e) {
+        logger.error("Internal Server Error: {}", e.getErrorResponse());
+        return ResponseEntity.internalServerError().body(e.getErrorResponse());
     }
 
     @ExceptionHandler

--- a/server/src/main/java/com/project/yozmcafe/controller/LoginArgumentResolver.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/LoginArgumentResolver.java
@@ -1,6 +1,7 @@
 package com.project.yozmcafe.controller;
 
-import javax.naming.AuthenticationException;
+import static com.project.yozmcafe.exception.ErrorCode.INVALID_TOKEN;
+import static com.project.yozmcafe.exception.ErrorCode.TOKEN_NOT_EXIST;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.project.yozmcafe.domain.member.Member;
 import com.project.yozmcafe.domain.member.MemberRepository;
+import com.project.yozmcafe.exception.TokenException;
 import com.project.yozmcafe.service.auth.JwtTokenProvider;
 
 @Component
@@ -34,19 +36,18 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
-                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
-            throws Exception {
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final String token = parseTokenFrom(webRequest);
 
         jwtTokenProvider.validate(token);
         return memberRepository.findById(jwtTokenProvider.getMemberId(token))
-                .orElseThrow(() -> new AuthenticationException("유효하지 않은 토큰입니다."));
+                .orElseThrow(() -> new TokenException(INVALID_TOKEN));
     }
 
-    private String parseTokenFrom(final NativeWebRequest webRequest) throws AuthenticationException {
+    private String parseTokenFrom(final NativeWebRequest webRequest) {
         String value = webRequest.getHeader(AUTHORIZATION);
         if (value == null) {
-            throw new AuthenticationException("유효한 사용자만 접근 가능합니다.");
+            throw new TokenException(TOKEN_NOT_EXIST);
         }
 
         return value.replace(BEARER, "");

--- a/server/src/main/java/com/project/yozmcafe/controller/auth/OAuthProvider.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/auth/OAuthProvider.java
@@ -1,10 +1,15 @@
 package com.project.yozmcafe.controller.auth;
 
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_OAUTH_CLIENT;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_OAUTH_PROVIDER;
+
 import java.util.Objects;
 
 import org.springframework.context.annotation.Configuration;
 
 import com.project.yozmcafe.domain.member.MemberInfo;
+import com.project.yozmcafe.exception.BadRequestException;
+import com.project.yozmcafe.exception.InternalServerException;
 import com.project.yozmcafe.service.auth.GoogleOAuthClient;
 import com.project.yozmcafe.service.auth.KakaoOAuthClient;
 import com.project.yozmcafe.service.auth.OAuthClient;
@@ -21,7 +26,7 @@ public enum OAuthProvider {
         try {
             return OAuthProvider.valueOf(providerName.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("잘못된 OAuth 로그인입니다.");
+            throw new BadRequestException(NOT_EXISTED_OAUTH_PROVIDER);
         }
     }
 
@@ -61,7 +66,7 @@ public enum OAuthProvider {
                     oAuthProvider.setOAuthClient(kakaoOAuthClient);
                 }
                 if (Objects.isNull(oAuthProvider.oAuthClient)) {
-                    throw new IllegalStateException("OAuthProvider에게 맞는 OAuthClient가 존재하지 않습니다.");
+                    throw new InternalServerException(NOT_EXISTED_OAUTH_CLIENT);
                 }
             }
         }

--- a/server/src/main/java/com/project/yozmcafe/controller/auth/OAuthProvider.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/auth/OAuthProvider.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.project.yozmcafe.domain.member.MemberInfo;
 import com.project.yozmcafe.exception.BadRequestException;
-import com.project.yozmcafe.exception.InternalServerException;
+import com.project.yozmcafe.exception.OAuthException;
 import com.project.yozmcafe.service.auth.GoogleOAuthClient;
 import com.project.yozmcafe.service.auth.KakaoOAuthClient;
 import com.project.yozmcafe.service.auth.OAuthClient;
@@ -66,7 +66,7 @@ public enum OAuthProvider {
                     oAuthProvider.setOAuthClient(kakaoOAuthClient);
                 }
                 if (Objects.isNull(oAuthProvider.oAuthClient)) {
-                    throw new InternalServerException(NOT_EXISTED_OAUTH_CLIENT);
+                    throw new OAuthException(NOT_EXISTED_OAUTH_CLIENT);
                 }
             }
         }

--- a/server/src/main/java/com/project/yozmcafe/domain/auth/token/OAuthToken.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/auth/token/OAuthToken.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.project.yozmcafe.domain.member.MemberInfo;
-import com.project.yozmcafe.exception.InternalServerException;
+import com.project.yozmcafe.exception.OAuthException;
 
 public abstract class OAuthToken {
 
@@ -53,7 +53,7 @@ public abstract class OAuthToken {
         final String entry = payLoads.stream()
                 .filter(payload -> payload.contains(key))
                 .findAny()
-                .orElseThrow((() -> new InternalServerException(INVALID_OAUTH_USER_INFO)));
+                .orElseThrow((() -> new OAuthException(INVALID_OAUTH_USER_INFO)));
 
         return entry.split(ENTRY_DELIMITER)[VALUE_INDEX];
     }

--- a/server/src/main/java/com/project/yozmcafe/domain/auth/token/OAuthToken.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/auth/token/OAuthToken.java
@@ -1,11 +1,14 @@
 package com.project.yozmcafe.domain.auth.token;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.project.yozmcafe.domain.member.MemberInfo;
+import static com.project.yozmcafe.exception.ErrorCode.INVALID_OAUTH_USER_INFO;
 
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.project.yozmcafe.domain.member.MemberInfo;
+import com.project.yozmcafe.exception.InternalServerException;
 
 public abstract class OAuthToken {
 
@@ -50,7 +53,7 @@ public abstract class OAuthToken {
         final String entry = payLoads.stream()
                 .filter(payload -> payload.contains(key))
                 .findAny()
-                .orElseThrow();
+                .orElseThrow((() -> new InternalServerException(INVALID_OAUTH_USER_INFO)));
 
         return entry.split(ENTRY_DELIMITER)[VALUE_INDEX];
     }

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/Images.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/Images.java
@@ -1,10 +1,14 @@
 package com.project.yozmcafe.domain.cafe;
 
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE_IMAGE;
+
+import java.util.List;
+
+import com.project.yozmcafe.exception.BadRequestException;
+
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
-
-import java.util.List;
 
 @Embeddable
 public class Images {
@@ -28,7 +32,7 @@ public class Images {
 
     public String getRepresentativeImage() {
         if (urls.isEmpty()) {
-            throw new IllegalArgumentException("카페 이미지가 존재하지 않습니다.");
+            throw new BadRequestException(NOT_EXISTED_CAFE_IMAGE);
         }
         return urls.get(REPRESENTATIVE_INDEX);
     }

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/Images.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/Images.java
@@ -1,10 +1,6 @@
 package com.project.yozmcafe.domain.cafe;
 
-import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE_IMAGE;
-
 import java.util.List;
-
-import com.project.yozmcafe.exception.BadRequestException;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
@@ -31,9 +27,6 @@ public class Images {
     }
 
     public String getRepresentativeImage() {
-        if (urls.isEmpty()) {
-            throw new BadRequestException(NOT_EXISTED_CAFE_IMAGE);
-        }
         return urls.get(REPRESENTATIVE_INDEX);
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -1,11 +1,15 @@
 package com.project.yozmcafe.domain.member;
 
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_LIKED_CAFE;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_UN_VIEWED_CAFE;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import com.project.yozmcafe.domain.cafe.Cafe;
 import com.project.yozmcafe.domain.cafe.LikedCafe;
 import com.project.yozmcafe.domain.cafe.UnViewedCafe;
+import com.project.yozmcafe.exception.BadRequestException;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -15,9 +19,6 @@ import jakarta.persistence.OneToMany;
 
 @Entity
 public class Member {
-
-    private static final String NOT_EXISTED_UNVIEWED_CAFE = "존재하지 않는 내역입니다.";
-    private static final String NOT_EXISTED_LIKED_CAFE = "존재하지 않는 좋아요 내역입니다.";
 
     @Id
     private String id;
@@ -54,7 +55,7 @@ public class Member {
                 .findAny()
                 .ifPresentOrElse(
                         unViewedCafes::remove, () -> {
-                            throw new IllegalArgumentException(NOT_EXISTED_UNVIEWED_CAFE);
+                            throw new BadRequestException(NOT_EXISTED_UN_VIEWED_CAFE);
                         }
                 );
     }
@@ -86,7 +87,7 @@ public class Member {
                 .filter(likedCafe -> likedCafe.isSameCafe(cafe))
                 .findAny()
                 .ifPresentOrElse(likedCafes::remove, () -> {
-                    throw new IllegalArgumentException(NOT_EXISTED_LIKED_CAFE);
+                    throw new BadRequestException(NOT_EXISTED_LIKED_CAFE);
                 });
         cafe.subtractLikeCount();
     }

--- a/server/src/main/java/com/project/yozmcafe/exception/BadRequestException.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/BadRequestException.java
@@ -1,14 +1,8 @@
 package com.project.yozmcafe.exception;
 
-public class BadRequestException extends RuntimeException {
-
-    private final ErrorResponse errorResponse;
+public class BadRequestException extends BaseException {
 
     public BadRequestException(final ErrorCode code) {
-        this.errorResponse = ErrorResponse.from(code);
-    }
-
-    public ErrorResponse getErrorResponse() {
-        return errorResponse;
+        super(code);
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/exception/BaseException.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/BaseException.java
@@ -1,0 +1,18 @@
+package com.project.yozmcafe.exception;
+
+public class BaseException extends RuntimeException {
+    private final ErrorResponse errorResponse;
+
+    public BaseException(final ErrorCode code) {
+        this.errorResponse = ErrorResponse.from(code);
+    }
+
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorResponse.getMessage();
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
@@ -9,9 +9,9 @@ public enum ErrorCode {
     NOT_EXISTED_UN_VIEWED_CAFE("U1", "UnViewed Cafe가 존재하지 않습니다."),
     NOT_EXISTED_LIKED_CAFE("L1", "Liked Cafe가 존재하지 않습니다."),
     NOT_EXISTED_CAFE_IMAGE("I1", "카페의 이미지가 존재하지 않습니다."),
-    INVALID_OAUTH_USER_INFO("OA1", "Provider로 부터 받은 사용자 정보의 확인이 필요합니다."),
-    NOT_EXISTED_OAUTH_PROVIDER("OP1", "잘못된 Provider Name 입니다."),
-    NOT_EXISTED_OAUTH_CLIENT("OC1", "일치하는 OAuthClient가 존재하지 않습니다.");
+    INVALID_OAUTH_USER_INFO("O1", "Provider로 부터 받은 사용자 정보의 확인이 필요합니다."),
+    NOT_EXISTED_OAUTH_PROVIDER("O2", "잘못된 Provider Name 입니다."),
+    NOT_EXISTED_OAUTH_CLIENT("O3", "일치하는 OAuthClient가 존재하지 않습니다.");
 
     private final String code;
     private final String message;

--- a/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
@@ -8,7 +8,6 @@ public enum ErrorCode {
     NOT_EXISTED_MEMBER("M1", "회원이 존재하지 않습니다."),
     NOT_EXISTED_UN_VIEWED_CAFE("U1", "UnViewed Cafe가 존재하지 않습니다."),
     NOT_EXISTED_LIKED_CAFE("L1", "Liked Cafe가 존재하지 않습니다."),
-    NOT_EXISTED_CAFE_IMAGE("I1", "카페의 이미지가 존재하지 않습니다."),
     INVALID_OAUTH_USER_INFO("O1", "Provider로 부터 받은 사용자 정보의 확인이 필요합니다."),
     NOT_EXISTED_OAUTH_PROVIDER("O2", "잘못된 Provider Name 입니다."),
     NOT_EXISTED_OAUTH_CLIENT("O3", "일치하는 OAuthClient가 존재하지 않습니다.");

--- a/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
@@ -9,8 +9,9 @@ public enum ErrorCode {
     NOT_EXISTED_UN_VIEWED_CAFE("U1", "UnViewed Cafe가 존재하지 않습니다."),
     NOT_EXISTED_LIKED_CAFE("L1", "Liked Cafe가 존재하지 않습니다."),
     NOT_EXISTED_CAFE_IMAGE("I1", "카페의 이미지가 존재하지 않습니다."),
+    INVALID_OAUTH_USER_INFO("OA1", "Provider로 부터 받은 사용자 정보의 확인이 필요합니다."),
     NOT_EXISTED_OAUTH_PROVIDER("OP1", "잘못된 Provider Name 입니다."),
-    NOT_EXISTED_OAUTH_CLIENT("OC1", "잘못된 Provider Name 입니다.");
+    NOT_EXISTED_OAUTH_CLIENT("OC1", "일치하는 OAuthClient가 존재하지 않습니다.");
 
     private final String code;
     private final String message;

--- a/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
@@ -3,7 +3,14 @@ package com.project.yozmcafe.exception;
 public enum ErrorCode {
     TOKEN_NOT_EXIST("T1", "토큰이 존재하지 않습니다."),
     TOKEN_IS_EXPIRED("T2", "만료된 토큰입니다."),
-    INVALID_TOKEN("T3", "잘못된 토큰입니다.");
+    INVALID_TOKEN("T3", "잘못된 토큰입니다."),
+    NOT_EXISTED_CAFE("C1", "카페가 존재하지 않습니다."),
+    NOT_EXISTED_MEMBER("M1", "회원이 존재하지 않습니다."),
+    NOT_EXISTED_UN_VIEWED_CAFE("U1", "UnViewed Cafe가 존재하지 않습니다."),
+    NOT_EXISTED_LIKED_CAFE("L1", "Liked Cafe가 존재하지 않습니다."),
+    NOT_EXISTED_CAFE_IMAGE("I1", "카페의 이미지가 존재하지 않습니다."),
+    NOT_EXISTED_OAUTH_PROVIDER("OP1", "잘못된 Provider Name 입니다."),
+    NOT_EXISTED_OAUTH_CLIENT("OC1", "잘못된 Provider Name 입니다.");
 
     private final String code;
     private final String message;

--- a/server/src/main/java/com/project/yozmcafe/exception/InternalServerException.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/InternalServerException.java
@@ -1,0 +1,8 @@
+package com.project.yozmcafe.exception;
+
+public class InternalServerException extends BaseException {
+
+    public InternalServerException(final ErrorCode code) {
+        super(code);
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/exception/InternalServerException.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/InternalServerException.java
@@ -1,8 +1,0 @@
-package com.project.yozmcafe.exception;
-
-public class InternalServerException extends BaseException {
-
-    public InternalServerException(final ErrorCode code) {
-        super(code);
-    }
-}

--- a/server/src/main/java/com/project/yozmcafe/exception/OAuthException.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/OAuthException.java
@@ -1,0 +1,8 @@
+package com.project.yozmcafe.exception;
+
+public class OAuthException extends BaseException {
+
+    public OAuthException(final ErrorCode code) {
+        super(code);
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/exception/TokenException.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/TokenException.java
@@ -1,14 +1,8 @@
 package com.project.yozmcafe.exception;
 
-public class TokenException extends RuntimeException {
-
-    private final ErrorResponse errorResponse;
+public class TokenException extends BaseException {
 
     public TokenException(final ErrorCode code) {
-        this.errorResponse = ErrorResponse.from(code);
-    }
-
-    public ErrorResponse getErrorResponse() {
-        return errorResponse;
+        super(code);
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/service/MemberService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/MemberService.java
@@ -1,5 +1,15 @@
 package com.project.yozmcafe.service;
 
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MEMBER;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.project.yozmcafe.controller.dto.LikedCafeResponse;
 import com.project.yozmcafe.controller.dto.MemberResponse;
 import com.project.yozmcafe.domain.cafe.Cafe;
@@ -7,12 +17,7 @@ import com.project.yozmcafe.domain.cafe.CafeRepository;
 import com.project.yozmcafe.domain.cafe.LikedCafe;
 import com.project.yozmcafe.domain.member.Member;
 import com.project.yozmcafe.domain.member.MemberRepository;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
+import com.project.yozmcafe.exception.BadRequestException;
 
 @Transactional(readOnly = true)
 @Service
@@ -44,13 +49,13 @@ public class MemberService {
 
     private Member findMemberByIdOrElseThrow(final String memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_EXISTED_MEMBER));
     }
 
     @Transactional
     public void updateLike(final Member member, final long cafeId, final boolean isLiked) {
         final Cafe cafe = cafeRepository.findById(cafeId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 카페가 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
         member.updateLikedCafesBy(cafe, isLiked);
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/service/auth/JwtTokenProvider.java
+++ b/server/src/main/java/com/project/yozmcafe/service/auth/JwtTokenProvider.java
@@ -1,5 +1,8 @@
 package com.project.yozmcafe.service.auth;
 
+import static com.project.yozmcafe.exception.ErrorCode.INVALID_TOKEN;
+import static com.project.yozmcafe.exception.ErrorCode.TOKEN_IS_EXPIRED;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
@@ -8,12 +11,17 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import io.jsonwebtoken.*;
+import com.project.yozmcafe.exception.TokenException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
 @Component
 public class JwtTokenProvider {
-    private static final String INVALID_TOKEN = "유효하지 않은 인증 정보입니다.";
 
     private final SecretKey key;
     private final long accessTokenExpired;
@@ -60,7 +68,7 @@ public class JwtTokenProvider {
         } catch (final ExpiredJwtException expired) {
             return expired.getClaims();
         } catch (final Exception e) {
-            throw new IllegalArgumentException(INVALID_TOKEN);
+            throw new TokenException(INVALID_TOKEN);
         }
     }
 
@@ -73,7 +81,7 @@ public class JwtTokenProvider {
         final Claims claims = toClaims(token);
 
         if (claims.getExpiration().before(new Date())) {
-            throw new IllegalArgumentException(INVALID_TOKEN);
+            throw new TokenException(TOKEN_IS_EXPIRED);
         }
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/controller/LoginArgumentResolverTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/LoginArgumentResolverTest.java
@@ -1,0 +1,50 @@
+package com.project.yozmcafe.controller;
+
+import static com.project.yozmcafe.exception.ErrorCode.TOKEN_IS_EXPIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import com.project.yozmcafe.util.AcceptanceContext;
+
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class LoginArgumentResolverTest {
+
+    @LocalServerPort
+    private int port;
+    @Autowired
+    private AcceptanceContext context;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("만료된 토큰으로 요청을 보내면, ErrorResponse를 응답한다.")
+    void invalidTokenFail() {
+        //given
+        context.accessToken = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTA4NjQ5NzQsImV4cCI6MTY5MDg2NTMzNCwic3ViIjoiMjkzOTU1Mzk2NyJ9.m8s0N30wn8g9eccIXRneOdhCsB_EZbR5etceyw2RaO4";
+
+        //when
+        context.invokeHttpGetWithToken("/cafes?page=1");
+        final String errorCode = context.response.jsonPath().getString("code");
+        final String errorMessage = context.response.jsonPath().getString("message");
+
+        //then
+        assertSoftly(softAssertions -> {
+                    assertThat(errorCode).isEqualTo(TOKEN_IS_EXPIRED.getCode());
+                    assertThat(errorMessage).isEqualTo(TOKEN_IS_EXPIRED.getMessage());
+                }
+        );
+    }
+}

--- a/server/src/test/java/com/project/yozmcafe/controller/StringToOAuthProviderConverterTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/StringToOAuthProviderConverterTest.java
@@ -1,11 +1,14 @@
 package com.project.yozmcafe.controller;
 
-import com.project.yozmcafe.controller.auth.OAuthProvider;
-import org.assertj.core.api.Assertions;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_OAUTH_PROVIDER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.project.yozmcafe.controller.auth.OAuthProvider;
+import com.project.yozmcafe.exception.BadRequestException;
 
 class StringToOAuthProviderConverterTest {
 
@@ -31,8 +34,8 @@ class StringToOAuthProviderConverterTest {
         final String nothing = "nothing";
 
         //when, then
-        Assertions.assertThatThrownBy(() -> converter.convert(nothing))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("잘못된 OAuth 로그인입니다.");
+        assertThatThrownBy(() -> converter.convert(nothing))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(NOT_EXISTED_OAUTH_PROVIDER.getMessage());
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/domain/auth/token/OAuthTokenTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/auth/token/OAuthTokenTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.project.yozmcafe.domain.member.MemberInfo;
-import com.project.yozmcafe.exception.InternalServerException;
+import com.project.yozmcafe.exception.OAuthException;
 
 class OAuthTokenTest {
 
@@ -40,7 +40,7 @@ class OAuthTokenTest {
 
         //when & then
         assertThatThrownBy(googleToken::toUserInfo)
-                .isInstanceOf(InternalServerException.class)
+                .isInstanceOf(OAuthException.class)
                 .hasMessage(INVALID_OAUTH_USER_INFO.getMessage());
 
 

--- a/server/src/test/java/com/project/yozmcafe/domain/auth/token/OAuthTokenTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/auth/token/OAuthTokenTest.java
@@ -1,11 +1,15 @@
 package com.project.yozmcafe.domain.auth.token;
 
-import com.project.yozmcafe.domain.member.MemberInfo;
+import static com.project.yozmcafe.exception.ErrorCode.INVALID_OAUTH_USER_INFO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import com.project.yozmcafe.domain.member.MemberInfo;
+import com.project.yozmcafe.exception.InternalServerException;
 
 class OAuthTokenTest {
 
@@ -25,5 +29,20 @@ class OAuthTokenTest {
                 () -> assertThat(memberInfo.openId()).isEqualTo("oceanId"),
                 () -> assertThat(memberInfo.image()).isEqualTo("oceanPicture")
         );
+    }
+
+    @Test
+    @DisplayName("Provider로 부터 받은 토큰의 payload에 subject, name, image 중 하나라도 존재하지 않으면 예외가 발생한다.")
+    void parseFail() {
+        //given
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaW1hZ2UiOiJpbWFnZSIsImlhdCI6MTUxNjIzOTAyMn0.SlwtSp0oOJpBToHUNul58kOEhbU7EfcFN3hESoo-DU4";
+        final GoogleToken googleToken = new GoogleToken(token);
+
+        //when & then
+        assertThatThrownBy(googleToken::toUserInfo)
+                .isInstanceOf(InternalServerException.class)
+                .hasMessage(INVALID_OAUTH_USER_INFO.getMessage());
+
+
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/domain/cafe/ImagesTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/cafe/ImagesTest.java
@@ -1,16 +1,11 @@
 package com.project.yozmcafe.domain.cafe;
 
-import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE_IMAGE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import com.project.yozmcafe.exception.BadRequestException;
 
 class ImagesTest {
 
@@ -26,18 +21,5 @@ class ImagesTest {
 
         //then
         assertThat(representativeImage).isEqualTo("오션.img");
-    }
-
-    @Test
-    @DisplayName("대표 이미지를 조회하는데 이미지가 없을 경우 예외가 발생한다.")
-    void getRepresentativeImage_fail() {
-        //given
-        final Images images = new Images(Collections.emptyList());
-
-        //when
-        //then
-        assertThatThrownBy(images::getRepresentativeImage)
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage(NOT_EXISTED_CAFE_IMAGE.getMessage());
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/domain/cafe/ImagesTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/cafe/ImagesTest.java
@@ -1,13 +1,16 @@
 package com.project.yozmcafe.domain.cafe;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE_IMAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.project.yozmcafe.exception.BadRequestException;
 
 class ImagesTest {
 
@@ -33,6 +36,8 @@ class ImagesTest {
 
         //when
         //then
-        assertThatThrownBy(images::getRepresentativeImage).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(images::getRepresentativeImage)
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(NOT_EXISTED_CAFE_IMAGE.getMessage());
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -1,20 +1,23 @@
 package com.project.yozmcafe.domain.member;
 
-import com.project.yozmcafe.domain.cafe.Cafe;
-import com.project.yozmcafe.domain.cafe.UnViewedCafe;
-import com.project.yozmcafe.fixture.Fixture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.UnViewedCafe;
+import com.project.yozmcafe.exception.BadRequestException;
+import com.project.yozmcafe.exception.ErrorCode;
+import com.project.yozmcafe.fixture.Fixture;
 
 class MemberTest {
 
@@ -66,8 +69,8 @@ class MemberTest {
 
         //when & then
         assertThatThrownBy(() -> member.removeUnViewedCafe(inValidUnViewedCafe))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 내역입니다.");
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.NOT_EXISTED_UN_VIEWED_CAFE.getMessage());
     }
 
     @Test

--- a/server/src/test/java/com/project/yozmcafe/service/MemberServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/MemberServiceTest.java
@@ -1,12 +1,13 @@
 package com.project.yozmcafe.service;
 
-import com.project.yozmcafe.controller.dto.LikedCafeResponse;
-import com.project.yozmcafe.controller.dto.MemberResponse;
-import com.project.yozmcafe.domain.cafe.Cafe;
-import com.project.yozmcafe.domain.cafe.CafeRepository;
-import com.project.yozmcafe.domain.member.Member;
-import com.project.yozmcafe.domain.member.MemberRepository;
-import com.project.yozmcafe.fixture.Fixture;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,11 +15,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import com.project.yozmcafe.controller.dto.LikedCafeResponse;
+import com.project.yozmcafe.controller.dto.MemberResponse;
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.CafeRepository;
+import com.project.yozmcafe.domain.member.Member;
+import com.project.yozmcafe.domain.member.MemberRepository;
+import com.project.yozmcafe.exception.BadRequestException;
+import com.project.yozmcafe.fixture.Fixture;
 
 @SpringBootTest
 @Transactional
@@ -49,8 +53,8 @@ class MemberServiceTest {
     @DisplayName("존재하지 않는 아이디로 회원을 조회하면 예외가 발생한다")
     void findById_fail() {
         assertThatThrownBy(() -> memberService.findById("nothing"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당하는 회원이 존재하지 않습니다.");
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(NOT_EXISTED_MEMBER.getMessage());
     }
 
     @Test
@@ -76,10 +80,10 @@ class MemberServiceTest {
         //given
         final PageRequest pageRequest = PageRequest.of(0, 1);
 
-        //when
-        //then
+        //when & then
         assertThatThrownBy(() -> memberService.findLikedCafesById("findLikedCafesById_fail", pageRequest))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(NOT_EXISTED_MEMBER.getMessage());
     }
 
     @Test
@@ -150,7 +154,7 @@ class MemberServiceTest {
 
         //when & then
         assertThatThrownBy(() -> memberService.updateLike(member, cafe.getId(), true))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당하는 카페가 존재하지 않습니다.");
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(NOT_EXISTED_CAFE.getMessage());
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/service/auth/JwtTokenProviderTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/auth/JwtTokenProviderTest.java
@@ -1,12 +1,15 @@
 package com.project.yozmcafe.service.auth;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
+import static com.project.yozmcafe.exception.ErrorCode.TOKEN_IS_EXPIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.project.yozmcafe.exception.TokenException;
 
 class JwtTokenProviderTest {
 
@@ -63,8 +66,8 @@ class JwtTokenProviderTest {
         assertSoftly(softAssertions -> {
             assertThat(payload).isEqualTo("연어");
             assertThatThrownBy(() -> provider.validate(token))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("유효하지 않은 인증 정보입니다.");
+                    .isInstanceOf(TokenException.class)
+                    .hasMessage(TOKEN_IS_EXPIRED.getMessage());
         });
     }
 
@@ -82,8 +85,8 @@ class JwtTokenProviderTest {
         //then
         assertSoftly(softAssertions -> {
             assertThatThrownBy(() -> provider.validate(access))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("유효하지 않은 인증 정보입니다.");
+                    .isInstanceOf(TokenException.class)
+                    .hasMessage(TOKEN_IS_EXPIRED.getMessage());
             assertThat(provider.getMemberId(access))
                     .isEqualTo(provider.getMemberId(refreshedAccessToken));
         });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> resolved #234

## 📝 작업 내용

custom Exception 적용했습니다.

## 💬 리뷰 요구사항

1. BaseException 생성
    custom Exception 내부가 다 똑같이 생겨서, BaseException 하나 따두고 그걸 extends 하는 방식으로 만들어 봤어요~
   
2. DependencyInjector 에서의 예외
    OAuthProvider의 inner 클래스 DependencyInjector에서 발생하는 예외를 뭘로 적용할지 고민하다가, 서버내부에러로 처리했어요.
    이거 같은 경우는 프론트의 요청과 상관없이 서버가 실행될때 적용되는 부분이라 이렇게 처리했는데, 다른 의견 있으시면 남겨주세요.
    
3. INVALID_TOKEN 과 TOKEN_NOT_EXIST 의 테스트코드
    이 예외들이 argumentResolver와 JwtTokenProvider에 적용을 시켰는데요. 해당 부분을 테스트하는 테스트코드가 없더라구요.
    로그인 작업하신 분들이 의도적으로 제외한 테스트인지 궁금하네요.
    필요하다면 제가 작성할게요.
    
4. `OAuthToken#parse` 에서의 예외
    ```java
        private String parse(final List<String> payLoads, final String key) {
        final String entry = payLoads.stream()
                .filter(payload -> payload.contains(key))
                .findAny()
                .orElseThrow();

        return entry.split(ENTRY_DELIMITER)[VALUE_INDEX];
    }
    ```
    현재 코드가 위와 같이 작성되어있는데, `orElseThrow`부분 예외를 던지지않더라구요.
    이 부분 예외가 발생할일이 없다고 생각하셔서 이렇게 처리하신건지 확인해주시면, 적절하게 처리해 볼게요.
