### PR TITLE
브라우저에 포커스가 다시 돌아왔을 때 메인 화면의 전체 데이터가 refetch되는 오류 수정

### DIFF
--- a/client/src/hooks/useCafes.ts
+++ b/client/src/hooks/useCafes.ts
@@ -7,7 +7,6 @@ import useAuth from './useAuth';
  * react-query의 `useInfiniteQuery` 를 사용하여 구현되었습니다.
  *
  * @example
- * ```
  * const Example = () => {
  *   const { cafes, fetchNextPage } = useCafes();
  *
@@ -17,7 +16,6 @@ import useAuth from './useAuth';
  *
  *   return <>{cafes.map((cafe) => <CafeExample key={cafe.id} cafe={cafe} />)}</>
  * }
- * ```
  */
 const useCafes = () => {
   const { identity } = useAuth();
@@ -28,6 +26,8 @@ const useCafes = () => {
         ? client.getCafes().then((cafes) => ({ cafes, page: pageParam }))
         : client.getCafesForGuest(pageParam).then((cafes) => ({ cafes, page: pageParam })),
     getNextPageParam: (lastPage) => (lastPage.cafes.length > 0 ? lastPage.page + 1 : undefined),
+    cacheTime: Infinity,
+    staleTime: Infinity,
   });
 
   return {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #232 

## 📝 작업 내용
* 다른 창에 갔다가 다시 돌아왔을 때 메인 화면의 카페 데이터가 모두 refetch되는 문제를 수정하였음
* react-query로 받아온 데이터가 절대 stale되지 않도록 함으로서 refetech가 되지 않도록 하였습니다.

## 💬 리뷰 요구사항