### PR TITLE
상세 모달 콘텐츠의 정렬을 맞춘다.

### DIFF
--- a/client/src/components/CafeDetailBottomSheet.tsx
+++ b/client/src/components/CafeDetailBottomSheet.tsx
@@ -28,17 +28,17 @@ const CafeDetailBottomSheet = ({ show, cafe, onClose }: CafeDetailBottomSheetPro
       </CloseButton>
       <Title>{cafe.name}</Title>
       <InfoContainer>
-        <LocationDetailContainer>
+        <LocationDetail>
           <BsGeoAlt />
           <a href={cafe.detail.mapUrl} target="_blank">
             <LocationName>
               {cafe.address} <BsBoxArrowUpRight />
             </LocationName>
           </a>
-        </LocationDetailContainer>
-        <OpeningHoursDetailContainer>
+        </LocationDetail>
+        <OpeningHoursDetails>
           <OpeningHoursDetail openingHours={cafe.detail.openingHours} />
-        </OpeningHoursDetailContainer>
+        </OpeningHoursDetails>
         {/* <Info>
           <BsTelephone />
           <h3>000-000-000</h3>
@@ -95,13 +95,13 @@ const InfoContainer = styled.div`
   gap: ${({ theme }) => theme.space[2]};
 `;
 
-const OpeningHoursDetailContainer = styled.div`
+const OpeningHoursDetails = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.space[2]};
   align-items: flex-start;
 `;
 
-const LocationDetailContainer = styled.div`
+const LocationDetail = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.space[2]};
   align-items: center;

--- a/client/src/components/CafeDetailBottomSheet.tsx
+++ b/client/src/components/CafeDetailBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { BsBoxArrowUpRight, BsClock, BsGeoAlt, BsX } from 'react-icons/bs';
+import { BsBoxArrowUpRight, BsGeoAlt, BsX } from 'react-icons/bs';
 import { styled } from 'styled-components';
 import { Cafe } from '../types';
 import OpeningHoursDetail from './OpeningHoursDetail';
@@ -28,18 +28,17 @@ const CafeDetailBottomSheet = ({ show, cafe, onClose }: CafeDetailBottomSheetPro
       </CloseButton>
       <Title>{cafe.name}</Title>
       <InfoContainer>
-        <Info>
+        <LocationDetailContainer>
           <BsGeoAlt />
           <a href={cafe.detail.mapUrl} target="_blank">
-            <h3>
+            <LocationName>
               {cafe.address} <BsBoxArrowUpRight />
-            </h3>
+            </LocationName>
           </a>
-        </Info>
-        <Info>
-          <BsClock />
+        </LocationDetailContainer>
+        <OpeningHoursDetailContainer>
           <OpeningHoursDetail openingHours={cafe.detail.openingHours} />
-        </Info>
+        </OpeningHoursDetailContainer>
         {/* <Info>
           <BsTelephone />
           <h3>000-000-000</h3>
@@ -96,10 +95,22 @@ const InfoContainer = styled.div`
   gap: ${({ theme }) => theme.space[2]};
 `;
 
-const Info = styled.div`
+const OpeningHoursDetailContainer = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.space[2]};
   align-items: flex-start;
+`;
+
+const LocationDetailContainer = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.space[2]};
+  align-items: center;
+`;
+
+const LocationName = styled.h3`
+  display: flex;
+  gap: ${({ theme }) => theme.space[1]};
+  align-items: center;
 `;
 
 const Content = styled.div`

--- a/client/src/components/OpeningHoursDetail.tsx
+++ b/client/src/components/OpeningHoursDetail.tsx
@@ -1,3 +1,4 @@
+import { BsClock } from 'react-icons/bs';
 import { styled } from 'styled-components';
 import { OpeningHour, OpeningHourDay } from '../types';
 
@@ -39,13 +40,15 @@ const OpeningHoursDetail = ({ openingHours }: OpeningHoursDetailProps) => {
 
   return (
     <Container>
-      <h3>{isOpenedToday() ? '영업중' : '영업 종료'}</h3>
-      <Summary>
-        {todayOpeningHour?.opened
-          ? `${DAY_MAPPER[todayOpeningHour.day]} ${todayOpeningHour.open} - ${todayOpeningHour.close}`
-          : '휴무'}
-      </Summary>
-
+      <SummaryDetailsContainer>
+        <BsClock />
+        <h3>{isOpenedToday() ? '영업중' : '영업 종료'}</h3>
+        <Summary>
+          {todayOpeningHour?.opened
+            ? `${DAY_MAPPER[todayOpeningHour.day]} ${todayOpeningHour.open} - ${todayOpeningHour.close}`
+            : '휴무'}
+        </Summary>
+      </SummaryDetailsContainer>
       <Details>
         {openingHours.map((openingHour) => (
           <li key={openingHour.day}>
@@ -59,19 +62,22 @@ const OpeningHoursDetail = ({ openingHours }: OpeningHoursDetailProps) => {
 
 export default OpeningHoursDetail;
 
-const Container = styled.div`
-  display: grid;
-  gap: ${({ theme }) => theme.space[2]};
-  align-items: center;
-`;
+const Container = styled.div``;
 
 const Summary = styled.h3``;
 
 const Details = styled.ul`
   display: flex;
-  grid-column: 2;
   flex-direction: column;
   gap: ${({ theme }) => theme.space[1]};
+  align-items: flex-end;
 
   color: ${({ theme }) => theme.color.gray};
+`;
+
+const SummaryDetailsContainer = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.space[2]};
+  align-items: center;
+  margin-bottom: ${({ theme }) => theme.space[1]};
 `;

--- a/client/src/components/OpeningHoursDetail.tsx
+++ b/client/src/components/OpeningHoursDetail.tsx
@@ -40,7 +40,7 @@ const OpeningHoursDetail = ({ openingHours }: OpeningHoursDetailProps) => {
 
   return (
     <Container>
-      <SummaryDetailsContainer>
+      <SummaryDetails>
         <BsClock />
         <h3>{isOpenedToday() ? '영업중' : '영업 종료'}</h3>
         <Summary>
@@ -48,7 +48,7 @@ const OpeningHoursDetail = ({ openingHours }: OpeningHoursDetailProps) => {
             ? `${DAY_MAPPER[todayOpeningHour.day]} ${todayOpeningHour.open} - ${todayOpeningHour.close}`
             : '휴무'}
         </Summary>
-      </SummaryDetailsContainer>
+      </SummaryDetails>
       <Details>
         {openingHours.map((openingHour) => (
           <li key={openingHour.day}>
@@ -75,7 +75,7 @@ const Details = styled.ul`
   color: ${({ theme }) => theme.color.gray};
 `;
 
-const SummaryDetailsContainer = styled.div`
+const SummaryDetails = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.space[2]};
   align-items: center;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #248 

## 📝 작업 내용

<img width="478" alt="스크린샷 2023-08-01 오후 2 50 54" src="https://github.com/woowacourse-teams/2023-yozm-cafe/assets/122500517/15e4e0da-cec8-4d06-bea5-e86fccda8a8b">

- 지도 아이콘과 주소 위아래 정렬, margin-bottom 추가, gap 수정
- 시계 아이콘과 영업중의 위아래 정렬, gap 수정, grid에서 flex로 수정

## 💬 리뷰 요구사항