### PR TITLE
access token이 만료되었을 때 자동으로 refresh되도록 구현

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -19,6 +19,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
 
   const identity = useMemo(() => {
     client.setAccessToken(accessToken);
+    client.onAccessTokenRefresh(setAccessToken);
 
     if (!accessToken) return null;
 

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -89,6 +89,28 @@ export const handlers = [
     );
   }),
 
+  rest.get('/api/auth', async (req, res, ctx) => {
+    const token =
+      btoa(
+        JSON.stringify({
+          typ: 'JWT',
+          alg: 'HS256',
+        }),
+      ) +
+      '.' +
+      btoa(
+        JSON.stringify({
+          sub: '1000',
+          iat: Date.now(),
+          exp: Date.now() + 1 * 60 * 60 * 1000,
+        } satisfies Identity),
+      ) +
+      '.' +
+      'SUPERSECRET';
+
+    return res(ctx.status(200), ctx.json({ token }));
+  }),
+
   rest.get('/api/auth/urls', async (req, res, ctx) => {
     return res(
       ctx.status(200),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #135 

## 📝 작업 내용
* access token이 만료되었을 때, `Client` 내부적으로 `/api/auth` 를 호출하여 access token이 재발급되고 사용되도록 하였다.
* 단 refresh token이 만료되었다면 다시 로그인해야 한다.
* refresh token이 만료되었을 때의 분기는 아직 처리하지 않았음 (향후 구현 필요)

## 💬 리뷰 요구사항