### PR TITLE
쿠키의 경로를 루트로 설정한다.

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/auth/AuthController.java
@@ -41,6 +41,7 @@ public class AuthController {
 
         final Cookie cookie = new Cookie(REFRESH_TOKEN, refreshTokenResponse.token());
         cookie.setMaxAge(COOKIE_MAX_AGE);
+        cookie.setPath("/");
         cookie.setHttpOnly(true);
         response.addCookie(cookie);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #274
## 📝 작업 내용

> 현재 쿠키 경로는 쿠키가 생성된 경로로 생성되고 있다.
> 이럴 경우 생성 경로 api 외에는 쿠키가 탑재가 되지 않는 문제가 생긴다.
> 그래서 이를         `cookie.setPath("/");`를 통해` yozm.cafe/ ` 이하에서는 모두 탑재할 수 있고 사용 가능하도록 수정했다.

## 💬 리뷰 요구사항
