### PR TITLE
비회원에게 랜덤한 카페를 조회해주는 기능 구현

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/service/CafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -28,9 +29,11 @@ public class CafeService {
     }
 
     public List<CafeResponse> getCafesForUnLoginMember(final Pageable pageable) {
-        final List<Cafe> foundCafes = cafeRepository.findSliceBy(pageable).getContent();
+        List<Cafe> allCafes = cafeRepository.findAll();
+        Collections.shuffle(allCafes);
 
-        return foundCafes.stream()
+        int pageSize = Math.min(allCafes.size(), pageable.getPageSize());
+        return allCafes.subList(0, pageSize).stream()
                 .map(CafeResponse::fromUnLoggedInUser)
                 .toList();
     }

--- a/server/src/test/java/com/project/yozmcafe/controller/CafeControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/CafeControllerTest.java
@@ -143,19 +143,6 @@ class CafeControllerTest {
     }
 
     @Test
-    @DisplayName("로그인 되지 않은 사용자가 /cafes/guest?page=? 에 GET요청을 보낸 경우 page가 최대 page를 초과하는 경우 빈배열을 반환한다.")
-    void getCafesEmptyByUnLoginUser() {
-        //when
-        context.invokeHttpGet("/cafes/guest?page=2000");
-
-        //then
-        assertAll(
-                () -> assertThat(context.response.statusCode()).isEqualTo(200),
-                () -> assertThat(context.response.jsonPath().getList("$")).isEmpty()
-        );
-    }
-
-    @Test
     @DisplayName("로그인한 사용자가 /cafes?page=?에 GET 요청을 보내면 아직보지않은 랜덤한,서로 다른 카페정보를 5개씩 응답한다.")
     void getCafesWithMember() {
         //given

--- a/server/src/test/java/com/project/yozmcafe/service/CafeServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/CafeServiceTest.java
@@ -62,8 +62,8 @@ class CafeServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 되지 않은 사용자의 안본 카페 목록을 조회한다.")
-    void getCafesForUnLoginMember() {
+    @DisplayName("로그인 되지 않은 사용자의 랜덤한 카페 목록을 조회한다. - 카페 정보가 5개 이하인 경우")
+    void getCafesForUnLoginMember1() {
         //given
         final PageRequest pageRequest = PageRequest.of(0, 5);
         cafeRepository.save(Fixture.getCafe("카페1", "주소1", 10));
@@ -78,5 +78,24 @@ class CafeServiceTest {
                 () -> assertThat(result.get(0).isLiked()).isFalse(),
                 () -> assertThat(result.get(1).isLiked()).isFalse()
         );
+    }
+
+    @Test
+    @DisplayName("로그인 되지 않은 사용자의 랜덤한 카페 목록을 조회한다. - 카페 정보가 5개 이상인 경우")
+    void getCafesForUnLoginMember2() {
+        //given
+        final PageRequest pageRequest = PageRequest.of(0, 5);
+        cafeRepository.save(Fixture.getCafe("카페1", "주소1", 10));
+        cafeRepository.save(Fixture.getCafe("카페2", "주소2", 11));
+        cafeRepository.save(Fixture.getCafe("카페3", "주소3", 10));
+        cafeRepository.save(Fixture.getCafe("카페4", "주소4", 11));
+        cafeRepository.save(Fixture.getCafe("카페5", "주소5", 10));
+        cafeRepository.save(Fixture.getCafe("카페6", "주소6", 11));
+
+        //when
+        final List<CafeResponse> result = cafeService.getCafesForUnLoginMember(pageRequest);
+
+        //then
+        assertThat(result).hasSize(5);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #257 

## 📝 작업 내용

> 비회원이 카페를 조회할 때, 카페들을 조회해 shuffle하고 pageSize만큼 응답한다.

## 💬 리뷰 요구사항

> 모든 카페를 조회하기에 최선의 방법도 아니고, 아직 비회원의 정책을 랜덤으로 하는 게 확실히 정해지지도 않았지만 
데모데이 전까지 비회원에게도 이 정도의 기능은 제공하는 게 완성도의 면에서 더 낫다고 생각했습니다.
꼭 merge할 필요는 없고 의논해보아요
