### PR TITLE
random.nextInt()에 0이 들어가지 않도록 수정

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/service/RandomPageRequestGenerator.java
+++ b/server/src/main/java/com/project/yozmcafe/service/RandomPageRequestGenerator.java
@@ -8,12 +8,16 @@ import java.security.SecureRandom;
 @Component
 public class RandomPageRequestGenerator {
 
+    private static final int FIRST_PAGE = 0;
     private final SecureRandom secureRandom = new SecureRandom();
 
     public RandomPageRequestGenerator() {
     }
 
     public PageRequest getPageRequestWithCafeCount(final Long unViewedCafeCount, final int pageSize) {
+        if (unViewedCafeCount <= pageSize) {
+            return PageRequest.of(FIRST_PAGE, pageSize);
+        }
         final int pageIdx = secureRandom.nextInt((int) Math.ceil((double) unViewedCafeCount / pageSize));
         return PageRequest.of(pageIdx, pageSize);
     }

--- a/server/src/test/java/com/project/yozmcafe/service/RandomPageRequestGeneratorTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/RandomPageRequestGeneratorTest.java
@@ -25,4 +25,20 @@ class RandomPageRequestGeneratorTest {
                 () -> assertThat(pageNumber).isLessThanOrEqualTo(12 / 5)
         );
     }
+
+    @DisplayName("생성된 pageRequest 의 페이지 범위가 카페 개수에 따라 가능한 범위 이내 이어야 한다.-전체 페이지가 1개인 경우")
+    @RepeatedTest(10)
+    void getPageRequest2() {
+        //given
+        //when
+        PageRequest result = pageRequestGenerator.getPageRequestWithCafeCount(3L, 5);
+
+        //then
+        int pageNumber = result.getPageNumber();
+
+        assertAll(
+                () -> assertThat(pageNumber).isGreaterThanOrEqualTo(0),
+                () -> assertThat(pageNumber).isLessThanOrEqualTo(3 / 5)
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #279 

## 📝 작업 내용

> nextInt()에 0이 들어가지 않도록 분기처리

## 💬 리뷰 요구사항
**연어의 pr https://github.com/woowacourse-teams/2023-yozm-cafe/pull/261 이 먼저 merge된다면 이 pr은 merge될 필요가 없습니다. 해당 pr에서 이 부분은 아예 삭제되기 때문입니다. 
이 경우에는 이 pr은 그냥 close하겠습니다.**
