### PR TITLE
좋아요 버튼의 좋아요 상태가 독립적으로 관리되는 문제 수정

### DIFF
--- a/client/src/components/LikeButton.tsx
+++ b/client/src/components/LikeButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PiHeartFill } from 'react-icons/pi';
 import { styled } from 'styled-components';
 
@@ -9,19 +9,20 @@ type LikeButtonProps = {
 };
 
 const LikeButton = ({ likeCount, active, onChange }: LikeButtonProps) => {
-  const [isLiked, setIsLiked] = useState(active);
   const [announce, setAnnounce] = useState('');
 
-  const handleLikeClick = () => {
-    setIsLiked((prevIsLiked) => !prevIsLiked);
-    setAnnounce(isLiked ? '좋아요 취소되었습니다.' : '좋아요가 추가되었습니다.');
+  useEffect(() => {
+    setAnnounce(active ? '좋아요 취소되었습니다.' : '좋아요가 추가되었습니다.');
     setTimeout(() => setAnnounce(''), 1000);
+  }, [active]);
+
+  const handleLikeClick = () => {
     onChange?.();
   };
 
   return (
     <Container aria-label="좋아요 버튼" tabIndex={0} role="button">
-      <HeartIcon $active={isLiked} onClick={handleLikeClick} />
+      <HeartIcon $active={active} onClick={handleLikeClick} />
       <LikeCount>{likeCount}</LikeCount>
       <Announcement aria-live="assertive" aria-atomic="true" aria-relevant="text">
         {`${likeCount} ${announce}`}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #284 

## 📝 작업 내용
* LikeButton을 stateful에서 stateless로 수정

## 💬 리뷰 요구사항