### PR TITLE
스와이프를 통해 카페의 좌우 사진을 볼 수 있도록 한다.

### DIFF
--- a/client/src/components/CafeCard.tsx
+++ b/client/src/components/CafeCard.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { BsChevronCompactLeft, BsChevronCompactRight } from 'react-icons/bs';
 import { styled } from 'styled-components';
 import useIntersection from '../hooks/useIntersection';
 import { Cafe } from '../types';
@@ -20,71 +19,48 @@ const CafeCard = (props: CardProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const intersection = useIntersection(ref, { threshold: 0.7 });
 
+  const handleScroll = () => {
+    if (ref.current) {
+      const { scrollLeft, clientWidth } = ref.current;
+      const index = Math.round(scrollLeft / clientWidth);
+      setCurrentImageIndex(index);
+    }
+  };
+
   useEffect(() => {
     if (intersection) {
       onIntersect?.(intersection);
     }
   }, [intersection?.isIntersecting]);
 
-  const getImageIndexByOffset = (offset: number) => {
-    const length = cafe.images.length;
-    return (currentImageIndex + length + offset) % length;
-  };
-
-  const getImageByOffset = (offset: number) => cafe.images[getImageIndexByOffset(offset)];
-
-  const handlePrevImage = () => {
-    setCurrentImageIndex(getImageIndexByOffset(-1));
-    announceImageChange('이전 이미지', currentImageIndex - 1);
-  };
-
-  const handleNextImage = () => {
-    setCurrentImageIndex(getImageIndexByOffset(1));
-    announceImageChange('다음 이미지', currentImageIndex + 1);
-  };
-
-  const announceImageChange = (action: string, imageIndex: number) => {
-    const message = `${cafe.name} 카페, ${imageIndex + 1}번째 사진입니다. ${action} 버튼을 클릭하셨습니다.`;
-
-    // 숨겨진 메시지를 화면에 추가하여 스크린 리더가 읽을 수 있게 함
-    // 하드 코딩이라 개선 필요
-
-    const announcementDiv = document.createElement('div');
-    announcementDiv.setAttribute('aria-live', 'polite');
-    announcementDiv.style.position = 'absolute';
-    announcementDiv.style.width = '1px';
-    announcementDiv.style.height = '1px';
-    announcementDiv.style.overflow = 'hidden';
-    document.body.appendChild(announcementDiv);
-
-    announcementDiv.textContent = message;
-
-    setTimeout(() => {
-      announcementDiv.remove();
-    }, 1000);
-  };
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.addEventListener('scroll', handleScroll);
+    }
+    return () => {
+      if (ref.current) {
+        ref.current.removeEventListener('scroll', handleScroll);
+      }
+    };
+  }, []);
 
   return (
     <Container>
+      <CardQuantityContainer>
+        <CardQuantityContents>
+          {`${currentImageIndex + 1}`}/{cafe.images.length}
+        </CardQuantityContents>
+      </CardQuantityContainer>
       <CarouselImageList ref={ref}>
-        <CarouselImage src={getImageByOffset(0)} alt={`Cafe Image ${currentImageIndex + 1}`} $show={true} />
-        {/* 이미지를 미리 불러오기 위한 장치 */}
-        <CarouselImage src={getImageByOffset(-1)} $show={false} aria-hidden="true" />
-        <CarouselImage src={getImageByOffset(1)} $show={false} aria-hidden="true" />
+        {cafe.images.map((image, index) => (
+          <CarouselImage key={index} src={image} alt={`${cafe}의 이미지`} />
+        ))}
       </CarouselImageList>
       <DotsContainer>
         {cafe.images.map((_, index) => (
-          <Dot key={index} active={index === currentImageIndex} onClick={() => setCurrentImageIndex(index)} />
+          <Dot key={index} active={index === currentImageIndex} />
         ))}
       </DotsContainer>
-      <CarouselNavigation>
-        <ButtonLeft onClick={handlePrevImage} aria-label="이전 이미지">
-          <BsChevronCompactLeft />
-        </ButtonLeft>
-        <ButtonRight onClick={handleNextImage} aria-label="다음 이미지">
-          <BsChevronCompactRight />
-        </ButtonRight>
-      </CarouselNavigation>
       <AsidePosition>
         <Aside>
           <CafeSummary
@@ -121,38 +97,25 @@ const Container = styled.div`
 `;
 
 const CarouselImageList = styled.div`
-  display: grid;
+  scroll-snap-type: x mandatory;
+
+  overflow-x: auto;
+  display: flex;
+
   width: 100%;
   height: 100%;
 `;
 
-const CarouselImage = styled.img<{ $show: boolean }>`
-  display: ${(props) => (props.$show ? 'initial' : 'none')};
-  grid-area: 1 / 1 / 1 / 1;
+const CarouselImage = styled.img`
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
 
-  width: 100%;
+  flex: 0 0 100%;
+
+  min-width: 100%;
   height: 100%;
 
   object-fit: cover;
-`;
-
-const CarouselNavigation = styled.div`
-  position: absolute;
-  top: 50%;
-
-  display: flex;
-  justify-content: space-between;
-
-  width: 100%;
-  & > * {
-    cursor: pointer;
-
-    font-size: ${({ theme }) => theme.fontSize['3xl']};
-    color: ${({ theme }) => theme.color.white};
-
-    background: none;
-    border: none;
-  }
 `;
 
 const DotsContainer = styled.div`
@@ -175,6 +138,25 @@ const Dot = styled.div<{ active: boolean }>`
   border-radius: 50%;
 `;
 
+const CardQuantityContainer = styled.div`
+  position: absolute;
+
+  display: flex;
+  justify-content: flex-end;
+
+  width: 100%;
+  padding: ${({ theme }) => theme.space['2.5']} ${({ theme }) => theme.space['2.5']} 0 0;
+
+  text-shadow: none;
+`;
+
+const CardQuantityContents = styled.div`
+  padding: ${({ theme }) => theme.space[1]} ${({ theme }) => theme.space[2]};
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  background-color: ${({ theme }) => theme.color.background.secondary};
+  border-radius: 10px;
+`;
+
 const AsidePosition = styled.div`
   position: absolute;
   bottom: 0;
@@ -187,7 +169,3 @@ const Aside = styled.div`
   flex-direction: column-reverse;
   padding-bottom: ${({ theme }) => theme.space[10]};
 `;
-
-const ButtonLeft = styled.button``;
-
-const ButtonRight = styled.button``;

--- a/client/src/components/CafeCard.tsx
+++ b/client/src/components/CafeCard.tsx
@@ -19,14 +19,6 @@ const CafeCard = (props: CardProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const intersection = useIntersection(ref, { threshold: 0.7 });
 
-  const handleScroll = () => {
-    if (ref.current) {
-      const { scrollLeft, clientWidth } = ref.current;
-      const index = Math.round(scrollLeft / clientWidth);
-      setCurrentImageIndex(index);
-    }
-  };
-
   useEffect(() => {
     if (intersection) {
       onIntersect?.(intersection);
@@ -34,6 +26,14 @@ const CafeCard = (props: CardProps) => {
   }, [intersection?.isIntersecting]);
 
   useEffect(() => {
+    const handleScroll = () => {
+      if (ref.current) {
+        const { scrollLeft, clientWidth } = ref.current;
+        const index = Math.round(scrollLeft / clientWidth);
+        setCurrentImageIndex(index);
+      }
+    };
+
     ref.current?.addEventListener('scroll', handleScroll);
     return () => {
       ref.current?.removeEventListener('scroll', handleScroll);

--- a/client/src/components/CafeCard.tsx
+++ b/client/src/components/CafeCard.tsx
@@ -34,13 +34,9 @@ const CafeCard = (props: CardProps) => {
   }, [intersection?.isIntersecting]);
 
   useEffect(() => {
-    if (ref.current) {
-      ref.current.addEventListener('scroll', handleScroll);
-    }
+    ref.current?.addEventListener('scroll', handleScroll);
     return () => {
-      if (ref.current) {
-        ref.current.removeEventListener('scroll', handleScroll);
-      }
+      ref.current?.removeEventListener('scroll', handleScroll);
     };
   }, []);
 

--- a/client/src/components/CafeDetailBottomSheet.tsx
+++ b/client/src/components/CafeDetailBottomSheet.tsx
@@ -75,9 +75,6 @@ const Container = styled.div<{ $show: boolean }>`
 
   background: ${({ theme }) => theme.color.white};
 
-  &::-webkit-scrollbar {
-    display: none;
-  }
   & svg {
     filter: none !important;
   }

--- a/client/src/components/LikedCafeList.tsx
+++ b/client/src/components/LikedCafeList.tsx
@@ -46,10 +46,6 @@ const TitleContainer = styled.article`
 const ScrollContainer = styled.div`
   overflow-y: scroll;
   flex: 1;
-
-  &::-webkit-scrollbar {
-    width: 0; /* 스크롤 바 너비 설정 */
-  }
 `;
 
 const GridContainer = styled.div`

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -48,10 +48,6 @@ const CardList = styled.ul`
   overflow-y: scroll;
   height: 100%;
 
-  &::-webkit-scrollbar {
-    display: none;
-  }
-
   & > * {
     scroll-snap-align: start;
     scroll-snap-stop: always;

--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -17,6 +17,10 @@ const GlobalStyle = createGlobalStyle`
 
   * {
     font-family: 'Pretendard', sans-serif;
+
+    &::-webkit-scrollbar {
+    display: none;
+  }
   }
 
   body {

--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -19,8 +19,8 @@ const GlobalStyle = createGlobalStyle`
     font-family: 'Pretendard', sans-serif;
 
     &::-webkit-scrollbar {
-    display: none;
-  }
+      display: none;
+    }
   }
 
   body {

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -22,7 +22,7 @@ const theme = {
 
     background: {
       primary: '#f8f8f8',
-      secondary: 'rgba(11, 19, 30, 0.67);',
+      secondary: 'rgba(0, 0, 0, 0.5);',
     },
   },
   fontSize: {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #287

## 📝 작업 내용

![화면 기록 2023-08-06 오전 11 12 01](https://github.com/woowacourse-teams/2023-yozm-cafe/assets/122500517/fbbdc061-3321-4c30-996f-9cd2c3ee54e9)

- [검정 바탕에 투명도 들어간 rgba 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/a1873bf6ee86551a99fca9727d0fb673150029c0)

- [스크롤 없애는 코드를 Globalstyle.ts에 추가 후, 나머지 파일에는 관련 코드 삭제](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/45e2bdddbce2ca388d68af248dec32cc9b5a75d1)

- [좌우 스크롤 기능 추가](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/4d646569d05c171a6691d0da4542227238781908)
---
## 스크롤 관련된 코드에 대한 설명

### 상태 추가: `const [currentImageIndex, setCurrentImageIndex] = useState(0); `
- `currentImageIndex`는 현재 보고 있는 이미지의 인덱스를 나타내는 상태입니다. 초기 값으로 0을 설정합니다.

### 스크롤 이벤트 처리 함수: `const handleScroll = () => { ... }`
```tsx
const handleScroll = () => {
  if (ref.current) {
    const { scrollLeft, clientWidth } = ref.current;
    const index = Math.round(scrollLeft / clientWidth);
    setCurrentImageIndex(index);
  }
};
```
 - `handleScroll` 함수는 이미지 리스트를 스크롤할 때 호출되는 함수입니다. 스크롤이 변경되면 현재 스크롤 위치를 계산하여 `currentImageIndex` 상태를 업데이트합니다.
 - `const { scrollLeft, clientWidth } = ref.current;`: `ref.current`는 `CarouselImageList` 컴포넌트의 DOM 요소를 참조하는 변수입니다. 여기서`scrollLeft`는 스크롤이 좌측으로부터 얼마나 떨어져 있는지를 나타내며, `clientWidth`는 컨테이너 요소의 가로 너비를 나타냅니다.
 - `const index = Math.round(scrollLeft / clientWidth);`: 스크롤이 얼마나 이동했는지를 이미지의 가로 너비로 나눈 값을 반올림하여 현재 보고 있는 이미지의 인덱스를 구합니다. 예를 들어, `scrollLeft`가 150px이고 `clientWidth`가 100px일 때, index는 1이 됩니다. 또한 `scrollLeft`가 250px이고 `clientWidth`가 100px일 때, index는 2가 됩니다.
 - `setCurrentImageIndex(index);`: 구한 이미지 인덱스를 `setCurrentImageIndex` 함수를 통해 `currentImageIndex` 상태에 업데이트합니다. 이렇게 함으로써 현재 보고 있는 이미지의 인덱스가 업데이트되면, 자동으로 dot의 위치도 해당 인덱스에 맞추어 표시됩니다.


### 스크롤 이벤트 리스너 등록과 해제: `useEffect(() => { ... }, []);`
 - `useEffect` 훅을 사용하여 컴포넌트가 처음 마운트될 때 스크롤 이벤트 리스너를 등록하고, 언마운트될 때 해당 리스너를 해제합니다. 이렇게 함으로써 컴포넌트가 마운트되어 있을 때만 스크롤 이벤트를 감지하도록 합니다. 
### 스크롤 이벤트 핸들러 내용: `if (ref.current) { ... }`
 - 스크롤 이벤트 핸들러 내부에서는 ref를 사용하여 실제 스크롤 위치를 가져옵니다. 
 - ref.current는 CarouselImageList 컴포넌트의 DOM 요소를 참조하는 변수입니다.
 - scrollLeft는 스크롤이 좌측으로부터 얼마나 떨어져 있는지를 나타내는 속성이며, clientWidth는 컨테이너 요소의 가로 너비를 나타냅니다.
 - 이 정보를 사용하여 현재 스크롤 위치를 계산하고, 그 위치에 해당하는 이미지의 인덱스를 구해 currentImageIndex를 업데이트합니다. 

이렇게 수정된 부분은 스크롤 이벤트를 감지하여 스크롤이 변경될 때마다 현재 보고 있는 이미지의 인덱스를 계산하고, 이를 토대로 dot의 위치를 자동으로 변경해줍니다. 사용자가 스크롤을 하면 dot도 자동으로 따라 움직이게 됩니다.









## 💬 리뷰 요구사항

pull 당겨서 이상 없는 지 확인해주세용
