### PR TITLE
`useQuery`의 타입 불일치(`TData | undefined`)를 해결하기 위한 `useSuspenseQuery` 구현

### DIFF
--- a/client/src/hooks/useAuthUrls.ts
+++ b/client/src/hooks/useAuthUrls.ts
@@ -1,13 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
 import client from '../client';
+import useSuspenseQuery from './useSuspenseQuery';
 
 const useAuthUrls = () => {
-  const queryResult = useQuery({
+  return useSuspenseQuery({
     queryKey: ['auth', 'urls'],
     queryFn: () => client.getAuthUrls(),
   });
-
-  return { ...queryResult, data: queryResult.data as NonNullable<typeof queryResult.data> };
 };
 
 export default useAuthUrls;

--- a/client/src/hooks/useSuspenseQuery.ts
+++ b/client/src/hooks/useSuspenseQuery.ts
@@ -1,0 +1,105 @@
+import { useQuery, type QueryKey, type UseQueryOptions, type UseQueryResult } from '@tanstack/react-query';
+
+type BaseUseSuspenseQueryResult<TData> = Omit<
+  UseQueryResult<TData, never>,
+  | 'data'
+  | 'enabled'
+  | 'status'
+  | 'error'
+  | 'isError'
+  | 'isLoading'
+  | 'isLoadingError'
+  | 'isInitialLoading'
+  | 'isSuccess'
+>;
+
+/**
+ * useSuspenseQuery가 성공한 경우의 결과 타입
+ */
+type UseSuspenseQueryResultOnSuccess<TData> = BaseUseSuspenseQueryResult<TData> & {
+  data: TData;
+  status: 'success';
+  isSuccess: true;
+  isIdle: false;
+};
+
+/**
+ * useSuspenseQuery가 대기(idle)중일 때의 결과 타입
+ */
+type UseSuspenseQueryResultOnIdle<TData> = BaseUseSuspenseQueryResult<TData> & {
+  data: undefined;
+  status: 'idle';
+  isSuccess: false;
+  isIdle: true;
+};
+
+type UseSuspenseQueryResult<TData> = UseSuspenseQueryResultOnSuccess<TData> | UseSuspenseQueryResultOnIdle<TData>;
+
+type UseSuspenseQueryOption<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'suspense'>;
+
+function useSuspenseQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(options: UseSuspenseQueryOption<TData, TError, TData, TQueryKey>): UseSuspenseQueryResultOnSuccess<TData>;
+
+function useSuspenseQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UseSuspenseQueryOption<TData, TError, TData, TQueryKey> & { enabled: true },
+): UseSuspenseQueryResultOnSuccess<TData>;
+
+function useSuspenseQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(options: UseSuspenseQueryOption<TData, TError, TData, TQueryKey> & { enabled: false }): UseSuspenseQueryResult<TData>;
+
+/**
+ * `suspense: true`일 때 data의 타입이 `TData | undefiend`로 나타나는 문제를 해결한
+ * 커스텀 훅입니다.
+ *
+ * suspense를 사용하면 성공한 결과밖에 반환합니다. 따라서 `TData | undefined`는 올바른
+ * 타입이 아니며, `TData` 가 올바른 타입입니다.
+ *
+ * @see https://github.com/woowacourse-teams/2023-yozm-cafe/issues/35
+ *
+ * @example
+ * const Example = () => {
+ *   const { data: cafes } = useSuspenseQuery({
+ *     queryKey: ['cafes'],
+ *     queryFn: () => client.getCafes(),
+ *   });
+ *
+ *   return <div>등록된 카페 수: {cafes.length}개</div>;
+ * }
+ */
+function useSuspenseQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UseSuspenseQueryOption<TQueryFnData, TError, TData, TQueryKey> & { enabled?: boolean },
+): UseSuspenseQueryResult<TData> {
+  const queryResult = useQuery({
+    ...options,
+    suspense: true,
+  });
+  return {
+    ...queryResult,
+    isIdle: 'isIdle' in queryResult ? queryResult.isIdle : false,
+  } as UseSuspenseQueryResult<TData>;
+}
+
+export default useSuspenseQuery;

--- a/client/src/hooks/useUser.ts
+++ b/client/src/hooks/useUser.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
 import client from '../client';
 import useAuth from './useAuth';
+import useSuspenseQuery from './useSuspenseQuery';
 
 /**
  * identity로 사용자 정보를 조회하고 응답받은 값을 반환합니다.
@@ -17,7 +17,7 @@ import useAuth from './useAuth';
 const useUser = () => {
   const { identity } = useAuth();
 
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['user', identity],
     queryFn: () => client.getUser(identity?.sub as string),
     enabled: !!identity,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #35 

## 📝 작업 내용
* suspense 를 활성화해도 useQuery의 `.data` 타입은 `TData | undefined`인데, 항상 성공하기 때문에 `TData` 타입이 올바르다고 할 수 있습니다.
* 따라서 `.data`가 `TData` 타입인 `useSuspenseQuery` 훅을 구현하였습니다.
* 그리고 `useQuery`를 사용하는 곳에 `useSuspenseQuery` 를 적용하였습니다.

## 💬 리뷰 요구사항
이 작업을 하게 된 배경에 대해서는 이슈를 참고해주세요.