### PR TITLE
likedCafes 반환시 page 초과할 경우 빈 리스트 반환

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -4,13 +4,10 @@ import com.project.yozmcafe.domain.cafe.Cafe;
 import com.project.yozmcafe.domain.cafe.LikedCafe;
 import com.project.yozmcafe.domain.cafe.UnViewedCafe;
 import com.project.yozmcafe.exception.BadRequestException;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_LIKED_CAFE;
@@ -105,6 +102,10 @@ public class Member {
     }
 
     public List<LikedCafe> getLikedCafesByPaging(int pageNum, int pageSize) {
+        if (pageNum - 1 > likedCafes.size() / pageSize) {
+            return Collections.emptyList();
+        }
+
         List<LikedCafe> reverseLikedCafes = new ArrayList<>(likedCafes);
         reverse(reverseLikedCafes);
 

--- a/server/src/test/java/com/project/yozmcafe/controller/LikedCafeControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/LikedCafeControllerTest.java
@@ -1,0 +1,143 @@
+package com.project.yozmcafe.controller;
+
+import com.project.yozmcafe.controller.dto.LikedCafeResponse;
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.CafeRepository;
+import com.project.yozmcafe.domain.member.Member;
+import com.project.yozmcafe.domain.member.MemberInfo;
+import com.project.yozmcafe.domain.member.MemberRepository;
+import com.project.yozmcafe.fixture.Fixture;
+import com.project.yozmcafe.service.auth.JwtTokenProvider;
+import com.project.yozmcafe.service.auth.KakaoOAuthClient;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+
+class LikedCafeControllerTest extends BaseControllerTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @SpyBean
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @Test
+    @DisplayName("사용자의 좋아요 한 카페 목록을 조회한다.")
+    void getLikedCafes() {
+        //given
+        final Cafe savedCafe1 = cafeRepository.save(Fixture.getCafe("오션의 귀여운 카페", "인천 오션동", 5));
+        final Cafe savedCafe2 = cafeRepository.save(Fixture.getCafe("오션의 귀여운 카페", "인천 오션동", 5));
+        final Member member = new Member("1234", "오션", "오션.img");
+        member.updateLikedCafesBy(savedCafe1, true);
+        member.updateLikedCafesBy(savedCafe2, true);
+        memberRepository.save(member);
+
+        //when
+        final Response response = given(spec).log().all()
+                .filter(document("좋아요 카페 목록 조회",
+                        queryParameters(parameterWithName("page").description("좋아요 목록 페이지 번호")),
+                        pathParameters(parameterWithName("memberId").description("멤버 ID")),
+                        responseFields(fieldWithPath("[].cafeId").description("카페 ID"),
+                                fieldWithPath("[].imageUrl").description("카페 대표 사진"))))
+                .when()
+                .get("/members/{memberId}/liked-cafes?page=1", member.getId());
+
+        //then
+        assertAll(
+                () -> assertThat(response.jsonPath().getLong("[0].cafeId")).isEqualTo(savedCafe2.getId()),
+                () -> assertThat(response.jsonPath().getLong("[1].cafeId")).isEqualTo(savedCafe1.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("멤버의 빈 좋아요 목록을 조회한다.")
+    void getLikedCafes_empty() {
+        //given
+        final Member member = new Member("1", "오션", "오션.img");
+        memberRepository.save(member);
+
+        //when
+        final Response response = given().log().all()
+                .when().get("/members/{memberId}/liked-cafes?page=1", member.getId());
+
+        //then
+        assertThat(response.jsonPath().getList("")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("재로그인 시 좋아요 목록이 남아있는다.")
+    void reLoginLikedListTest() {
+        //given
+        final Cafe cafe = cafeRepository.save(Fixture.getCafe("카페1", "주소1", 10));
+        final Member member = memberRepository.save(
+                new Member("memberId", "폴로", "폴로사진"));
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(member.getId());
+        doReturn(new MemberInfo(member.getId(), member.getName(), member.getImage()))
+                .when(kakaoOAuthClient).getUserInfo(anyString());
+
+        //when
+        given().log().all()
+                .auth().oauth2("accessToken")
+                .post("/cafes/" + cafe.getId() + "/likes?isLiked=true");
+
+        reLogin();
+
+        final Response response = given().log().all()
+                .when().get("/members/{memberId}/liked-cafes?size=1&page=1", member.getId());
+
+        final List<LikedCafeResponse> result = response.jsonPath().getList("");
+
+        //then
+        assertThat(result).hasSize(1);
+    }
+
+    private void reLogin() {
+        given()
+                .log().all()
+                .queryParam("code", "googleCode")
+                .when()
+                .post("/auth/{providerName}", "kakao");
+    }
+
+    @Test
+    @DisplayName("사용자가 카페에 대해 좋아요를 할 수 있다.")
+    void updateLikes() {
+        //given
+        final Member member = memberRepository.save(
+                new Member("123", "오션", "오션사진"));
+        final Cafe cafe = cafeRepository.save(Fixture.getCafe(1L, "카페1", "주소1", 10));
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(member.getId());
+
+        //when
+        final Response response = given(spec).log().all()
+                .filter(document("좋아요",
+                        queryParameters(parameterWithName("isLiked").description("좋아요 여부 확인")),
+                        pathParameters(parameterWithName("cafeId").description("카페 ID"))))
+                .auth().oauth2("accessToken")
+                .post("/cafes/{cafeId}/likes?isLiked=true", cafe.getId());
+
+        response.then()
+                .statusCode(HttpStatus.OK.value());
+    }
+}

--- a/server/src/test/java/com/project/yozmcafe/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/MemberControllerTest.java
@@ -1,51 +1,24 @@
 package com.project.yozmcafe.controller;
 
+import com.project.yozmcafe.controller.dto.MemberResponse;
+import com.project.yozmcafe.domain.member.Member;
+import com.project.yozmcafe.domain.member.MemberRepository;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-
-import com.project.yozmcafe.controller.dto.LikedCafeResponse;
-import com.project.yozmcafe.controller.dto.MemberResponse;
-import com.project.yozmcafe.domain.cafe.Cafe;
-import com.project.yozmcafe.domain.cafe.CafeRepository;
-import com.project.yozmcafe.domain.member.Member;
-import com.project.yozmcafe.domain.member.MemberInfo;
-import com.project.yozmcafe.domain.member.MemberRepository;
-import com.project.yozmcafe.fixture.Fixture;
-import com.project.yozmcafe.service.auth.JwtTokenProvider;
-import com.project.yozmcafe.service.auth.KakaoOAuthClient;
-import com.project.yozmcafe.util.AcceptanceContext;
-
-import io.restassured.RestAssured;
-import io.restassured.response.Response;
-
 class MemberControllerTest extends BaseControllerTest {
 
     @Autowired
     private MemberRepository memberRepository;
-    @Autowired
-    private CafeRepository cafeRepository;
-    @Autowired
-    private AcceptanceContext context;
-    @MockBean
-    private JwtTokenProvider jwtTokenProvider;
-    @SpyBean
-    private KakaoOAuthClient kakaoOAuthClient;
 
     @Test
     @DisplayName("id로 멤버 조회")
@@ -72,74 +45,5 @@ class MemberControllerTest extends BaseControllerTest {
 
         //then
         assertThat(response).isEqualTo(expected);
-    }
-
-    @Test
-    @DisplayName("멤버의 좋아요 목록을 조회할 수 있다.")
-    void getLikedCafes() {
-        //given
-        final Cafe savedCafe1 = cafeRepository.save(Fixture.getCafe("오션의 귀여운 카페", "인천 오션동", 5));
-        final Cafe savedCafe2 = cafeRepository.save(Fixture.getCafe("오션의 귀여운 카페", "인천 오션동", 5));
-        final Member member = new Member("1234", "오션", "오션.img");
-        member.updateLikedCafesBy(savedCafe1, true);
-        member.updateLikedCafesBy(savedCafe2, true);
-        memberRepository.save(member);
-
-        //when
-        context.invokeHttpGet("/members/{memberId}/liked-cafes?page=1", member.getId());
-        Response response = context.response;
-
-        //then
-        assertAll(
-                () -> assertThat(response.jsonPath().getLong("[0].cafeId")).isEqualTo(savedCafe2.getId()),
-                () -> assertThat(response.jsonPath().getLong("[1].cafeId")).isEqualTo(savedCafe1.getId())
-        );
-    }
-
-    @Test
-    @DisplayName("멤버의 빈 좋아요 목록을 조회한다.")
-    void getLikedCafes_empty() {
-        //given
-        final Member member = new Member("1", "오션", "오션.img");
-        memberRepository.save(member);
-
-        //when
-        context.invokeHttpGet("/members/{memberId}/liked-cafes?page=1", member.getId());
-        Response response = context.response;
-
-        //then
-        assertThat(response.jsonPath().getList("")).isEmpty();
-    }
-
-    @Test
-    @DisplayName("재로그인 시 좋아요 목록이 남아있는다.")
-    void reLoginLikedListTest() {
-        //given
-        final Cafe cafe = cafeRepository.save(Fixture.getCafe("카페1", "주소1", 10));
-        final Member member = memberRepository.save(
-                new Member("memberId", "폴로", "폴로사진"));
-
-        given(jwtTokenProvider.getMemberId(anyString())).willReturn(member.getId());
-        doReturn(new MemberInfo(member.getId(), member.getName(), member.getImage())).when(kakaoOAuthClient)
-                .getUserInfo(anyString());
-
-        //when
-        context.accessToken = "accessToken";
-        context.invokeHttpPostWithToken("/cafes/" + cafe.getId() + "/likes?isLiked=true");
-        reLogin();
-        context.invokeHttpGet("/members/{memberId}/liked-cafes?size=1&page=1", member.getId());
-
-        final List<LikedCafeResponse> result = context.response.jsonPath().getList("");
-
-        //then
-        assertThat(result).hasSize(1);
-    }
-
-    private void reLogin() {
-        RestAssured.given()
-                .log().all()
-                .queryParam("code", "googleCode")
-                .when()
-                .post("/auth/{providerName}", "kakao");
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -241,4 +241,21 @@ class MemberTest {
         //then
         assertThat(likedCafes).map(LikedCafe::getCafe).containsExactly(cafe4, cafe3);
     }
+
+    @Test
+    @DisplayName("좋아요 목록 수를 초과한 page 요청 시 빈 list를 반환한다.")
+    void getLikedCafesByPaging_empty() {
+        //given
+        final Member member = new Member("1234", "오션", "오션사진");
+        final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);
+        final Cafe cafe2 = Fixture.getCafe(2L, "카페2", "주소2", 3);
+        member.updateLikedCafesBy(cafe1, true);
+        member.updateLikedCafesBy(cafe2, true);
+
+        //when
+        final List<LikedCafe> likedCafes = member.getLikedCafesByPaging(2, 2);
+
+        //then
+        assertThat(likedCafes).isEmpty();
+    }
 }

--- a/server/src/test/java/com/project/yozmcafe/service/auth/OAuthProviderTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/auth/OAuthProviderTest.java
@@ -1,9 +1,10 @@
-package com.project.yozmcafe.controller.auth;
+package com.project.yozmcafe.service.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.project.yozmcafe.controller.auth.OAuthProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #315 

## 📝 작업 내용
 ```
if (pageNum - 1 > likedCafes.size() / pageSize) {
            return Collections.emptyList();
        }
```
> 프론트로부터 요청 페이지 숫자가 1 이상이기에 -1 처리를 진행하였고, 
likedCafes.size()/pageSize가 결국 요청할 수 있는 최대 page 이므로 이것을 넘어갈 경우 빈 리스트를 반환하게 하였습니다

## 💬 리뷰 요구사항

