### PR TITLE
likedCafesPaging 검증 추가

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/controller/LikedCafeController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/LikedCafeController.java
@@ -23,7 +23,7 @@ public class LikedCafeController {
     @GetMapping("/members/{memberId}/liked-cafes")
     public ResponseEntity<List<LikedCafeResponse>> getLikedCafes(@PathVariable("memberId") final String memberId,
                                                                  @PathParam("page") final int page) {
-        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(memberId, page, PAGE_SIZE);
+        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(memberId, page - 1, PAGE_SIZE);
         return ResponseEntity.ok(likedCafes);
     }
 

--- a/server/src/main/java/com/project/yozmcafe/controller/LikedCafeController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/LikedCafeController.java
@@ -3,7 +3,8 @@ package com.project.yozmcafe.controller;
 import com.project.yozmcafe.controller.dto.LikedCafeResponse;
 import com.project.yozmcafe.domain.member.Member;
 import com.project.yozmcafe.service.LikedCafeService;
-import jakarta.websocket.server.PathParam;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,8 +23,8 @@ public class LikedCafeController {
 
     @GetMapping("/members/{memberId}/liked-cafes")
     public ResponseEntity<List<LikedCafeResponse>> getLikedCafes(@PathVariable("memberId") final String memberId,
-                                                                 @PathParam("page") final int page) {
-        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(memberId, page - 1, PAGE_SIZE);
+                                                                 @PageableDefault(size = PAGE_SIZE) final Pageable pageable) {
+        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(memberId, pageable);
         return ResponseEntity.ok(likedCafes);
     }
 

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_LIKED_CAFE;
@@ -106,15 +105,11 @@ public class Member {
         return result;
     }
 
-    public List<LikedCafe> getLikedCafesByPaging(final int pageNumber, final int pageSize) {
-        if (pageNumber - 1 > likedCafes.size() / pageSize) {
-            return Collections.emptyList();
-        }
-
+    public List<LikedCafe> getLikedCafesSection(final int pageNumber, final int pageSize) {
         List<LikedCafe> reverseLikedCafes = new ArrayList<>(this.likedCafes);
         reverse(reverseLikedCafes);
 
-        int startIndex = (pageNumber - 1) * pageSize;
+        int startIndex = pageNumber * pageSize;
         int endIndex = min(startIndex + pageSize, likedCafes.size());
 
         return reverseLikedCafes.subList(startIndex, endIndex);

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_LIKED_CAFE;
@@ -105,14 +106,18 @@ public class Member {
         return result;
     }
 
-    public List<LikedCafe> getLikedCafesByPaging(int pageNumber, int pageSize) {
-        List<LikedCafe> likedCafes = new ArrayList<>(this.likedCafes);
-        reverse(likedCafes);
+    public List<LikedCafe> getLikedCafesByPaging(final int pageNumber, final int pageSize) {
+        if (pageNumber - 1 > likedCafes.size() / pageSize) {
+            return Collections.emptyList();
+        }
+
+        List<LikedCafe> reverseLikedCafes = new ArrayList<>(this.likedCafes);
+        reverse(reverseLikedCafes);
 
         int startIndex = (pageNumber - 1) * pageSize;
         int endIndex = min(startIndex + pageSize, likedCafes.size());
 
-        return likedCafes.subList(startIndex, endIndex);
+        return reverseLikedCafes.subList(startIndex, endIndex);
     }
 
     public String getId() {

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_LIKED_CAFE;
@@ -105,14 +106,15 @@ public class Member {
         return result;
     }
 
-    public List<LikedCafe> getLikedCafesSection(final int pageNumber, final int pageSize) {
+    public List<LikedCafe> getLikedCafesSection(final int startIndex, final int endIndex) {
+        if (startIndex >= likedCafes.size()){
+            return Collections.emptyList();
+        }
+
         List<LikedCafe> reverseLikedCafes = new ArrayList<>(this.likedCafes);
         reverse(reverseLikedCafes);
 
-        int startIndex = pageNumber * pageSize;
-        int endIndex = min(startIndex + pageSize, likedCafes.size());
-
-        return reverseLikedCafes.subList(startIndex, endIndex);
+        return reverseLikedCafes.subList(startIndex, min(endIndex, likedCafes.size()));
     }
 
     public String getId() {

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -111,7 +111,7 @@ public class Member {
             return Collections.emptyList();
         }
 
-        List<LikedCafe> reverseLikedCafes = new ArrayList<>(this.likedCafes);
+        final List<LikedCafe> reverseLikedCafes = new ArrayList<>(likedCafes);
         reverse(reverseLikedCafes);
 
         return reverseLikedCafes.subList(startIndex, min(endIndex, likedCafes.size()));

--- a/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
@@ -5,6 +5,7 @@ import com.project.yozmcafe.domain.cafe.Cafe;
 import com.project.yozmcafe.domain.cafe.CafeRepository;
 import com.project.yozmcafe.domain.cafe.LikedCafe;
 import com.project.yozmcafe.domain.member.Member;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,17 +25,20 @@ public class LikedCafeService {
         this.memberService = memberService;
     }
 
-    public List<LikedCafeResponse> findLikedCafesById(final String memberId, final int pageNumber, final int pageSize) {
+    public List<LikedCafeResponse> findLikedCafesById(final String memberId, final Pageable pageable) {
         final Member member = memberService.findMemberByIdOrElseThrow(memberId);
 
-        List<LikedCafe> likedCafes = getLikedCafes(pageNumber, pageSize, member);
+        final List<LikedCafe> likedCafes = getLikedCafes(pageable, member);
 
         return likedCafes.stream()
                 .map(LikedCafeResponse::from)
                 .toList();
     }
 
-    private List<LikedCafe> getLikedCafes(final int pageNumber, final int pageSize, final Member member) {
+    private List<LikedCafe> getLikedCafes(final Pageable pageable, final Member member) {
+        int pageNumber = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
+
         if (pageNumber > member.getLikedCafes().size() / pageSize) {
             return Collections.emptyList();
         }

--- a/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
@@ -35,8 +35,8 @@ public class LikedCafeService {
     }
 
     private List<LikedCafe> getLikedCafes(final Pageable pageable, final Member member) {
-        int startIndex = pageable.getPageNumber() * pageable.getPageSize();
-        int endIndex = startIndex + pageable.getPageSize();
+        final int startIndex = pageable.getPageNumber() * pageable.getPageSize();
+        final int endIndex = startIndex + pageable.getPageSize();
 
         return member.getLikedCafesSection(startIndex, endIndex);
     }

--- a/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -36,13 +35,10 @@ public class LikedCafeService {
     }
 
     private List<LikedCafe> getLikedCafes(final Pageable pageable, final Member member) {
-        int pageNumber = pageable.getPageNumber();
-        int pageSize = pageable.getPageSize();
+        int startIndex = pageable.getPageNumber() * pageable.getPageSize();
+        int endIndex = startIndex + pageable.getPageSize();
 
-        if (pageNumber > member.getLikedCafes().size() / pageSize) {
-            return Collections.emptyList();
-        }
-        return member.getLikedCafesSection(pageNumber, pageSize);
+        return member.getLikedCafesSection(startIndex, endIndex);
     }
 
     @Transactional

--- a/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/LikedCafeService.java
@@ -8,6 +8,7 @@ import com.project.yozmcafe.domain.member.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -26,11 +27,18 @@ public class LikedCafeService {
     public List<LikedCafeResponse> findLikedCafesById(final String memberId, final int pageNumber, final int pageSize) {
         final Member member = memberService.findMemberByIdOrElseThrow(memberId);
 
-        final List<LikedCafe> likedCafes = member.getLikedCafesByPaging(pageNumber, pageSize);
+        List<LikedCafe> likedCafes = getLikedCafes(pageNumber, pageSize, member);
 
         return likedCafes.stream()
                 .map(LikedCafeResponse::from)
                 .toList();
+    }
+
+    private List<LikedCafe> getLikedCafes(final int pageNumber, final int pageSize, final Member member) {
+        if (pageNumber > member.getLikedCafes().size() / pageSize) {
+            return Collections.emptyList();
+        }
+        return member.getLikedCafesSection(pageNumber, pageSize);
     }
 
     @Transactional

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -236,26 +236,9 @@ class MemberTest {
         member.updateLikedCafesBy(cafe4, true);
 
         //when
-        final List<LikedCafe> likedCafes = member.getLikedCafesByPaging(1, 2);
+        final List<LikedCafe> likedCafes = member.getLikedCafesSection(0, 2);
 
         //then
         assertThat(likedCafes).map(LikedCafe::getCafe).containsExactly(cafe4, cafe3);
-    }
-
-    @Test
-    @DisplayName("좋아요 목록 수를 초과한 page 요청 시 빈 list를 반환한다.")
-    void getLikedCafesByPaging_empty() {
-        //given
-        final Member member = new Member("1234", "오션", "오션사진");
-        final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);
-        final Cafe cafe2 = Fixture.getCafe(2L, "카페2", "주소2", 3);
-        member.updateLikedCafesBy(cafe1, true);
-        member.updateLikedCafesBy(cafe2, true);
-
-        //when
-        final List<LikedCafe> likedCafes = member.getLikedCafesByPaging(2, 2);
-
-        //then
-        assertThat(likedCafes).isEmpty();
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -223,7 +223,7 @@ class MemberTest {
 
     @Test
     @DisplayName("좋아요한 카페 목록을 페이지 처리한다")
-    void getLikedCafesByPaging() {
+    void getLikedCafesSection() {
         //given
         final Member member = new Member("1234", "오션", "오션사진");
         final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -241,4 +241,21 @@ class MemberTest {
         //then
         assertThat(likedCafes).map(LikedCafe::getCafe).containsExactly(cafe4, cafe3);
     }
+
+    @Test
+    @DisplayName("좋아요 목록 수를 초과한 page 요청 시 빈 list를 반환한다.")
+    void getLikedCafesByPaging_empty() {
+        //given
+        final Member member = new Member("1234", "오션", "오션사진");
+        final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);
+        final Cafe cafe2 = Fixture.getCafe(2L, "카페2", "주소2", 3);
+        member.updateLikedCafesBy(cafe1, true);
+        member.updateLikedCafesBy(cafe2, true);
+
+        //when
+        final List<LikedCafe> likedCafes = member.getLikedCafesByPaging(2, 2);
+
+        //then
+        assertThat(likedCafes).isEmpty();
+    }
 }

--- a/server/src/test/java/com/project/yozmcafe/service/LikedCafeServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/LikedCafeServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -37,11 +38,12 @@ class LikedCafeServiceTest {
         //given
         final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션의 귀여운 카페", "인천 오션동", 5));
         final Member member = new Member("1234", "오션", "오션.img");
+        final PageRequest pageRequest = PageRequest.of(0, 15);
         member.updateLikedCafesBy(savedCafe, true);
         memberRepository.save(member);
 
         //when
-        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(member.getId(), 0, 15);
+        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(member.getId(), pageRequest);
 
         //then
         assertThat(likedCafes.get(0).cafeId()).isEqualTo(savedCafe.getId());
@@ -51,9 +53,11 @@ class LikedCafeServiceTest {
     @DisplayName("좋아요 카페 목록을 조회할 멤버가 없을 경우 예외가 발생한다.")
     void findLikedCafesById_fail() {
         //given
+        final PageRequest pageRequest = PageRequest.of(0, 15);
+
         //when
         //then
-        assertThatThrownBy(() -> likedCafeService.findLikedCafesById("findLikedCafesById_fail", 0, 15))
+        assertThatThrownBy(() -> likedCafeService.findLikedCafesById("findLikedCafesById_fail", pageRequest))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(NOT_EXISTED_MEMBER.getMessage());
     }
@@ -65,11 +69,12 @@ class LikedCafeServiceTest {
         final Member member = memberRepository.save(new Member("1234", "오션", "오션사진"));
         final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);
         final Cafe cafe2 = Fixture.getCafe(2L, "카페2", "주소2", 3);
+        final PageRequest pageRequest = PageRequest.of(1, 2);
         member.updateLikedCafesBy(cafe1, true);
         member.updateLikedCafesBy(cafe2, true);
 
         //when
-        final List<LikedCafeResponse> likedCafesById = likedCafeService.findLikedCafesById(member.getId(), 1, 2);
+        final List<LikedCafeResponse> likedCafesById = likedCafeService.findLikedCafesById(member.getId(), pageRequest);
 
         //then
         assertThat(likedCafesById).isEmpty();

--- a/server/src/test/java/com/project/yozmcafe/service/LikedCafeServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/LikedCafeServiceTest.java
@@ -41,7 +41,7 @@ class LikedCafeServiceTest {
         memberRepository.save(member);
 
         //when
-        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(member.getId(), 1, 15);
+        final List<LikedCafeResponse> likedCafes = likedCafeService.findLikedCafesById(member.getId(), 0, 15);
 
         //then
         assertThat(likedCafes.get(0).cafeId()).isEqualTo(savedCafe.getId());
@@ -53,9 +53,26 @@ class LikedCafeServiceTest {
         //given
         //when
         //then
-        assertThatThrownBy(() -> likedCafeService.findLikedCafesById("findLikedCafesById_fail", 1, 15))
+        assertThatThrownBy(() -> likedCafeService.findLikedCafesById("findLikedCafesById_fail", 0, 15))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(NOT_EXISTED_MEMBER.getMessage());
+    }
+
+    @Test
+    @DisplayName("좋아요 목록 수를 초과한 page 요청 시 빈 list를 반환한다.")
+    void findLikedCafesById_empty() {
+        //given
+        final Member member = memberRepository.save(new Member("1234", "오션", "오션사진"));
+        final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);
+        final Cafe cafe2 = Fixture.getCafe(2L, "카페2", "주소2", 3);
+        member.updateLikedCafesBy(cafe1, true);
+        member.updateLikedCafesBy(cafe2, true);
+
+        //when
+        final List<LikedCafeResponse> likedCafesById = likedCafeService.findLikedCafesById(member.getId(), 1, 2);
+
+        //then
+        assertThat(likedCafesById).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #315 

## 📝 작업 내용
 ```
if (pageNum  > likedCafes.size() / pageSize) {
            return Collections.emptyList();
        }
```
> 기존에는 최대 page를 넘어선 요청이 올 경우 에러가 발생했습니다.
이를 page param으로 받는게 아닌 pageable을 통해 처리하도록 진행하였습니다.
likedCafes.size()/pageSize가 결국 요청할 수 있는 최대 page 이므로 이것을 넘어갈 경우 빈 리스트를 반환하게 하였습니다.

## 💬 리뷰 요구사항

> 고민 1 빈 리스트를 넘겨주는 코드가 service 단 vs 도메인 단 
> 고민 2 getLikedCafesSection 메소드명 뭔가 페이징을 드러내고 싶지가 않음

