### PR TITLE
카페 단 건 조회 API 개발 - 공유하기

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/controller/CafeController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/CafeController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,4 +36,12 @@ public class CafeController {
         List<CafeResponse> cafeResponses = cafeService.getCafesForUnLoginMember(pageable);
         return ResponseEntity.ok(cafeResponses);
     }
+
+    @GetMapping("/{cafeId}")
+    public ResponseEntity<CafeResponse> getCafeById(@PathVariable("cafeId") final long cafeId) {
+        CafeResponse cafeResponse = cafeService.getCafeById(cafeId);
+        return ResponseEntity.ok(cafeResponse);
+    }
 }
+
+

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/CafeRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/CafeRepository.java
@@ -4,8 +4,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CafeRepository extends JpaRepository<Cafe, Long> {
 
     Slice<Cafe> findSliceBy(Pageable pageable);
 
+    Optional<Cafe> findById(Long id);
 }
+

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/CafeRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/CafeRepository.java
@@ -4,12 +4,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface CafeRepository extends JpaRepository<Cafe, Long> {
 
     Slice<Cafe> findSliceBy(Pageable pageable);
-
-    Optional<Cafe> findById(Long id);
 }
 

--- a/server/src/main/java/com/project/yozmcafe/service/CafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -29,6 +30,13 @@ public class CafeService {
         return foundCafes.stream()
                 .map(CafeResponse::fromUnLoggedInUser)
                 .toList();
+    }
+
+    public CafeResponse getCafeById(long cafeId) {
+        Optional<Cafe> foundCafe = cafeRepository.findById(cafeId);
+
+        return foundCafe.map(CafeResponse::fromUnLoggedInUser)
+                .orElse(null);
     }
 
     @Transactional

--- a/server/src/main/java/com/project/yozmcafe/service/CafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeService.java
@@ -34,13 +34,6 @@ public class CafeService {
                 .toList();
     }
 
-    public CafeResponse getCafeById(long cafeId) {
-        Cafe foundCafe = cafeRepository.findById(cafeId)
-                .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
-
-        return CafeResponse.fromUnLoggedInUser(foundCafe);
-    }
-
     @Transactional
     public List<CafeResponse> getCafesForLoginMember(final Member member, final int size) {
         final List<UnViewedCafe> cafes = member.getNextUnViewedCafes(size);
@@ -50,5 +43,12 @@ public class CafeService {
                 .map(UnViewedCafe::getCafe)
                 .map(cafe -> CafeResponse.fromLoggedInUser(cafe, member.isLike(cafe)))
                 .toList();
+    }
+
+    public CafeResponse getCafeById(final long cafeId) {
+        Cafe foundCafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
+
+        return CafeResponse.fromUnLoggedInUser(foundCafe);
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/service/CafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeService.java
@@ -5,12 +5,14 @@ import com.project.yozmcafe.domain.cafe.Cafe;
 import com.project.yozmcafe.domain.cafe.CafeRepository;
 import com.project.yozmcafe.domain.cafe.UnViewedCafe;
 import com.project.yozmcafe.domain.member.Member;
+import com.project.yozmcafe.exception.BadRequestException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
+
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE;
 
 @Service
 @Transactional(readOnly = true)
@@ -33,10 +35,10 @@ public class CafeService {
     }
 
     public CafeResponse getCafeById(long cafeId) {
-        Optional<Cafe> foundCafe = cafeRepository.findById(cafeId);
+        Cafe foundCafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
 
-        return foundCafe.map(CafeResponse::fromUnLoggedInUser)
-                .orElse(null);
+        return CafeResponse.fromUnLoggedInUser(foundCafe);
     }
 
     @Transactional

--- a/server/src/main/java/com/project/yozmcafe/service/CafeService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeService.java
@@ -46,7 +46,7 @@ public class CafeService {
     }
 
     public CafeResponse getCafeById(final long cafeId) {
-        Cafe foundCafe = cafeRepository.findById(cafeId)
+        final Cafe foundCafe = cafeRepository.findById(cafeId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
 
         return CafeResponse.fromUnLoggedInUser(foundCafe);

--- a/server/src/test/java/com/project/yozmcafe/controller/CafeControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/CafeControllerTest.java
@@ -169,7 +169,8 @@ class CafeControllerTest extends BaseControllerTest {
                 .filter(document(CAFE_API + "카페 id로 단 건 조회",
                         pathParameters(parameterWithName("cafeId").description("카페 Id")),
                         getOneCafeResponseFields()))
-                .when().get("/cafes/{cafeId}", cafe3.getId());
+                .when()
+                .get("/cafes/{cafeId}", cafe3.getId());
 
         //then
         Long resultId = response.then().log().all().extract().jsonPath().getLong("id");
@@ -184,8 +185,9 @@ class CafeControllerTest extends BaseControllerTest {
     @DisplayName("카페 id로 해당하는 카페를 조회할 때, 존재하지 않는 카페이면 null을 반환한다")
     void findByIdWhenNotExist() {
         //when
-        final Response response = given(spec).log().all()
-                .when().get("/cafes/{cafeId}", 9999999L);
+        final Response response = given().log().all()
+                .when()
+                .get("/cafes/{cafeId}", 9999999L);
 
         //then
         assertAll(

--- a/server/src/test/java/com/project/yozmcafe/controller/CafeControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/CafeControllerTest.java
@@ -182,7 +182,7 @@ class CafeControllerTest extends BaseControllerTest {
     }
 
     @Test
-    @DisplayName("카페 id로 해당하는 카페를 조회할 때, 존재하지 않는 카페이면 null을 반환한다")
+    @DisplayName("카페 id로 해당하는 카페를 조회할 때, 존재하지 않는 카페이면 statusCode 400을 응답한다")
     void findByIdWhenNotExist() {
         //when
         final Response response = given().log().all()
@@ -190,10 +190,7 @@ class CafeControllerTest extends BaseControllerTest {
                 .get("/cafes/{cafeId}", 9999999L);
 
         //then
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(200),
-                () -> assertThat(response.getBody().asString()).isEmpty()
-        );
+        assertThat(response.statusCode()).isEqualTo(400);
     }
 
     @Test

--- a/server/src/test/java/com/project/yozmcafe/domain/cafe/CafeRepositoryTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/cafe/CafeRepositoryTest.java
@@ -59,4 +59,15 @@ class CafeRepositoryTest {
         assertThat(cafes).hasSize(5);
         assertThat(cafes).containsExactlyInAnyOrder(cafe1, cafe2, cafe3, cafe4, cafe5);
     }
+
+    @Test
+    @DisplayName("id를 통해 카페를 조회한다.")
+    void findById() {
+        //when
+        final Cafe cafe = cafeRepository.findById(cafe1.getId()).get();
+
+        //then
+        assertThat(cafe).usingRecursiveComparison().isEqualTo(cafe1);
+    }
 }
+

--- a/server/src/test/java/com/project/yozmcafe/domain/cafe/CafeRepositoryTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/cafe/CafeRepositoryTest.java
@@ -59,15 +59,4 @@ class CafeRepositoryTest {
         assertThat(cafes).hasSize(5);
         assertThat(cafes).containsExactlyInAnyOrder(cafe1, cafe2, cafe3, cafe4, cafe5);
     }
-
-    @Test
-    @DisplayName("id를 통해 카페를 조회한다.")
-    void findById() {
-        //when
-        final Cafe cafe = cafeRepository.findById(cafe1.getId()).get();
-
-        //then
-        assertThat(cafe).usingRecursiveComparison().isEqualTo(cafe1);
-    }
 }
-

--- a/server/src/test/java/com/project/yozmcafe/service/CafeServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/CafeServiceTest.java
@@ -5,6 +5,7 @@ import com.project.yozmcafe.domain.cafe.Cafe;
 import com.project.yozmcafe.domain.cafe.CafeRepository;
 import com.project.yozmcafe.domain.member.Member;
 import com.project.yozmcafe.domain.member.MemberRepository;
+import com.project.yozmcafe.exception.BadRequestException;
 import com.project.yozmcafe.fixture.Fixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_CAFE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
@@ -71,5 +74,33 @@ class CafeServiceTest {
                 () -> assertThat(result.get(0).isLiked()).isFalse(),
                 () -> assertThat(result.get(1).isLiked()).isFalse()
         );
+    }
+
+    @Test
+    @DisplayName("id로 카페를 단 건 조회한다.")
+    void getCafeById() {
+        //given
+        final Cafe savedCafe1 = cafeRepository.save(Fixture.getCafe("카페1", "주소1", 10));
+        final Cafe savedCafe2 = cafeRepository.save(Fixture.getCafe("카페2", "주소2", 11));
+
+        //when
+        final CafeResponse result = cafeService.getCafeById(savedCafe1.getId());
+
+        //then
+        assertThat(result.id()).isEqualTo(savedCafe1.getId());
+    }
+
+    @Test
+    @DisplayName("id로 카페를 단 건 조회할 때, 존재하지 않는 카페이면 예외가 발생한다.")
+    void getCafeByIdFailWhenNotExist() {
+        //given
+        cafeRepository.save(Fixture.getCafe("카페1", "주소1", 10));
+        cafeRepository.save(Fixture.getCafe("카페2", "주소2", 11));
+        final long notExistCafeId = 9999L;
+
+        //when, then
+        assertThatThrownBy(() -> cafeService.getCafeById(notExistCafeId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(NOT_EXISTED_CAFE.getMessage());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolved #326 

## 📝 작업 내용

- 공유하기와 관련하여 카페 id를 통한 단 건 조회 API를 개발

## 💬 리뷰 요구사항

존재하지 않는 카페를 조회하려할 때 1)예외를 던지는 방법 2)null,빈 배열 등을 응답하는 방법 등
이 있을 것 같습니다. 
공유하기를 통해 삭제된 카페를 보려할 경우 적절한 안내 메시지(ex-존재하지 않는 카페입니다)가 노출되어야 한다고 생각해서
프론트에서 어떤 응답을 받았을 때 존재하지 않는 카페라 판단할 지 합의가 필요합니다
지금은 우선 예외상황은 아닌 듯해 존재하지 않는 카페이면 null을 responseBody에 담아 응답하도록 구현했습니다.

+ controllerTest의 존재하지 않는 카페 조회 - 실패 케이스도 API문서화를 하려했는데
responseBody가 null일때는 에러를 발생시킵니다.
![image](https://github.com/woowacourse-teams/2023-yozm-cafe/assets/96762301/42a988ba-465a-4faf-bc66-62ca49ee8220)
