### PR TITLE
storybook이 프로젝트의 webpack.config.js의 설정을 사용하도록 설정

### DIFF
--- a/client/.storybook/webpack.config.js
+++ b/client/.storybook/webpack.config.js
@@ -1,0 +1,6 @@
+import { merge } from 'webpack-merge';
+import defaultConfig from '../webpack.config.js';
+
+export default function ({ config }) {
+  return merge(defaultConfig, config);
+}

--- a/client/package.json
+++ b/client/package.json
@@ -66,7 +66,8 @@
     "typescript": "^5.1.6",
     "webpack": "^5.88.1",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-dev-server": "^4.15.1",
+    "webpack-merge": "^5.9.0"
   },
   "msw": {
     "workerDirectory": "public"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9915,7 +9915,7 @@ webpack-hot-middleware@^2.25.1:
     html-entities "^2.1.0"
     strip-ansi "^6.0.0"
 
-webpack-merge@^5.7.3:
+webpack-merge@^5.7.3, webpack-merge@^5.9.0:
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.9.0.tgz#dc160a1c4cf512ceca515cc231669e9ddb133826"
   integrity sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #337 

## 📝 작업 내용
![image](https://github.com/woowacourse-teams/2023-yozm-cafe/assets/20203944/a89f035d-a3c7-4d6e-90c7-3cb5e2d41b38)

* storybook이 프로젝트의 webpack.config.js 설정을 기반으로 사용하도록 작업하였습니다.
* copy-webpack-plugin이 잘 적용되었으며 이미지 잘 뜹니다.

## 💬 리뷰 요구사항