### PR TITLE
메뉴 조회 기능 추가

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/controller/MenuController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/MenuController.java
@@ -1,0 +1,25 @@
+package com.project.yozmcafe.controller;
+
+import com.project.yozmcafe.controller.dto.menu.MenuResponse;
+import com.project.yozmcafe.service.MenuService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MenuController {
+
+    private final MenuService menuService;
+
+    public MenuController(final MenuService menuService) {
+        this.menuService = menuService;
+    }
+
+    @GetMapping("/cafes/{cafeId}/menus")
+    public ResponseEntity<MenuResponse> getMenus(@PathVariable("cafeId") final Long cafeId) {
+        final MenuResponse menuResponse = menuService.getMenus(cafeId);
+
+        return ResponseEntity.ok(menuResponse);
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuBoardResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuBoardResponse.java
@@ -1,0 +1,9 @@
+package com.project.yozmcafe.controller.dto.menu;
+
+import com.project.yozmcafe.domain.menu.MenuBoard;
+
+public record MenuBoardResponse(Long id, Long priority, String imageUrl) {
+    public static MenuBoardResponse from(MenuBoard menuBoards) {
+        return new MenuBoardResponse(menuBoards.getId(), menuBoards.getPriority(), menuBoards.getImageUrl());
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuBoardResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuBoardResponse.java
@@ -2,7 +2,7 @@ package com.project.yozmcafe.controller.dto.menu;
 
 import com.project.yozmcafe.domain.menu.MenuBoard;
 
-public record MenuBoardResponse(Long id, Long priority, String imageUrl) {
+public record MenuBoardResponse(Long id, int priority, String imageUrl) {
     public static MenuBoardResponse from(final MenuBoard menuBoards) {
         return new MenuBoardResponse(menuBoards.getId(), menuBoards.getPriority(), menuBoards.getImageUrl());
     }

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuBoardResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuBoardResponse.java
@@ -3,7 +3,7 @@ package com.project.yozmcafe.controller.dto.menu;
 import com.project.yozmcafe.domain.menu.MenuBoard;
 
 public record MenuBoardResponse(Long id, Long priority, String imageUrl) {
-    public static MenuBoardResponse from(MenuBoard menuBoards) {
+    public static MenuBoardResponse from(final MenuBoard menuBoards) {
         return new MenuBoardResponse(menuBoards.getId(), menuBoards.getPriority(), menuBoards.getImageUrl());
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuItemResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuItemResponse.java
@@ -1,0 +1,11 @@
+package com.project.yozmcafe.controller.dto.menu;
+
+import com.project.yozmcafe.domain.menu.Menu;
+
+public record MenuItemResponse(Long id, String name, Long priority, String imageUrl, String description, String price,
+                               boolean isRecommended) {
+    public static MenuItemResponse from(final Menu menu) {
+        return new MenuItemResponse(menu.getId(), menu.getName(), menu.getPriority(), menu.getImageUrl(),
+                menu.getDescription(), menu.getPrice(), menu.isRecommended());
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuItemResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuItemResponse.java
@@ -2,7 +2,7 @@ package com.project.yozmcafe.controller.dto.menu;
 
 import com.project.yozmcafe.domain.menu.Menu;
 
-public record MenuItemResponse(Long id, String name, Long priority, String imageUrl, String description, String price,
+public record MenuItemResponse( Long id, String name, Long priority, String imageUrl, String description, String price,
                                boolean isRecommended) {
     public static MenuItemResponse from(final Menu menu) {
         return new MenuItemResponse(menu.getId(), menu.getName(), menu.getPriority(), menu.getImageUrl(),

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuItemResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuItemResponse.java
@@ -2,7 +2,7 @@ package com.project.yozmcafe.controller.dto.menu;
 
 import com.project.yozmcafe.domain.menu.Menu;
 
-public record MenuItemResponse( Long id, String name, Long priority, String imageUrl, String description, String price,
+public record MenuItemResponse( Long id, String name, int priority, String imageUrl, String description, String price,
                                boolean isRecommended) {
     public static MenuItemResponse from(final Menu menu) {
         return new MenuItemResponse(menu.getId(), menu.getName(), menu.getPriority(), menu.getImageUrl(),

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuResponse.java
@@ -1,0 +1,19 @@
+package com.project.yozmcafe.controller.dto.menu;
+
+import com.project.yozmcafe.domain.menu.Menu;
+import com.project.yozmcafe.domain.menu.MenuBoard;
+
+import java.util.List;
+
+public record MenuResponse(Long cafeId, List<MenuBoardResponse> menuBoards, List<MenuItemResponse> menus) {
+    public static MenuResponse of(final Long cafeId, List<MenuBoard> menuBoards, List<Menu> menus) {
+        final List<MenuBoardResponse> menuBoardResponses = menuBoards.stream()
+                .map(MenuBoardResponse::from)
+                .toList();
+
+        final List<MenuItemResponse> menuItemResponses = menus.stream()
+                .map(MenuItemResponse::from)
+                .toList();
+        return new MenuResponse(cafeId, menuBoardResponses, menuItemResponses);
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuResponse.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/dto/menu/MenuResponse.java
@@ -6,7 +6,7 @@ import com.project.yozmcafe.domain.menu.MenuBoard;
 import java.util.List;
 
 public record MenuResponse(Long cafeId, List<MenuBoardResponse> menuBoards, List<MenuItemResponse> menus) {
-    public static MenuResponse of(final Long cafeId, List<MenuBoard> menuBoards, List<Menu> menus) {
+    public static MenuResponse of(final Long cafeId, final List<MenuBoard> menuBoards, final List<Menu> menus) {
         final List<MenuBoardResponse> menuBoardResponses = menuBoards.stream()
                 .map(MenuBoardResponse::from)
                 .toList();

--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/Cafe.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/Cafe.java
@@ -1,12 +1,7 @@
 package com.project.yozmcafe.domain.cafe;
 
 import com.project.yozmcafe.exception.BadRequestException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 import java.util.Objects;
 
@@ -40,6 +35,7 @@ public class Cafe {
 
     @Embedded
     private Detail detail;
+
     private int likeCount;
 
     protected Cafe() {

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
@@ -33,7 +33,7 @@ public class Menu {
     private Cafe cafe;
 
     @Column(nullable = false)
-    private Long priority;
+    private int priority;
 
     @Column(nullable = false)
     private String name;
@@ -50,11 +50,11 @@ public class Menu {
     protected Menu() {
     }
 
-    public Menu(final Cafe cafe, final Long priority, final String name, final String imageUrl, final String description, final String price, final boolean isRecommended) {
+    public Menu(final Cafe cafe, final int priority, final String name, final String imageUrl, final String description, final String price, final boolean isRecommended) {
         this(null, cafe, priority, name, imageUrl, description, price, isRecommended);
     }
 
-    public Menu(final Long id, final Cafe cafe, final Long priority, final String name, final String imageUrl, final String description,
+    public Menu(final Long id, final Cafe cafe, final int priority, final String name, final String imageUrl, final String description,
                 final String price, final boolean isRecommended) {
         validate(name, price);
         this.id = id;
@@ -84,7 +84,7 @@ public class Menu {
         return cafe;
     }
 
-    public Long getPriority() {
+    public int getPriority() {
         return priority;
     }
 

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
@@ -1,10 +1,17 @@
 package com.project.yozmcafe.domain.menu;
 
 import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.exception.BadRequestException;
 import jakarta.persistence.*;
+
+import static com.project.yozmcafe.exception.ErrorCode.INVALID_MENU_NAME;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MENU_PRICE;
+import static io.micrometer.common.util.StringUtils.isBlank;
 
 @Entity
 public class Menu {
+
+    public static final int MAX_NAME_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -12,9 +19,80 @@ public class Menu {
 
     @ManyToOne
     private Cafe cafe;
+
+    @Column(nullable = false)
+    private Long priority;
+
+    @Column(nullable = false)
     private String name;
+
     private String imageUrl;
+
     private String description;
+
+    @Column(nullable = false)
     private String price;
+
     private boolean isRecommended;
+
+    protected Menu() {
+    }
+
+    public Menu(final Cafe cafe, final Long priority, final String name, final String imageUrl, final String description, final String price, final boolean isRecommended) {
+        this(null, cafe, priority, name, imageUrl, description, price, isRecommended);
+    }
+
+    public Menu(final Long id, final Cafe cafe, final Long priority, final String name, final String imageUrl, final String description,
+                final String price, final boolean isRecommended) {
+        validate(name, price);
+        this.id = id;
+        this.cafe = cafe;
+        this.priority = priority;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.description = description;
+        this.price = price;
+        this.isRecommended = isRecommended;
+    }
+
+    private void validate(final String name, final String price) {
+        if (isBlank(name) || name.length() > MAX_NAME_LENGTH) {
+            throw new BadRequestException(INVALID_MENU_NAME);
+        }
+        if (isBlank(price)) {
+            throw new BadRequestException(NOT_EXISTED_MENU_PRICE);
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Cafe getCafe() {
+        return cafe;
+    }
+
+    public Long getPriority() {
+        return priority;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public boolean isRecommended() {
+        return isRecommended;
+    }
 }

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
@@ -29,7 +29,7 @@ public class Menu {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Cafe cafe;
 
     @Column(nullable = false)

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
@@ -9,6 +9,18 @@ import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MENU_PRICE;
 import static io.micrometer.common.util.StringUtils.isBlank;
 
 @Entity
+@Table(
+    name = "Menu",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_cafe_priority",
+            columnNames = {
+                "cafe_id",
+                "priority"
+            }
+        )
+    }
+)
 public class Menu {
 
     public static final int MAX_NAME_LENGTH = 20;

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
@@ -1,0 +1,20 @@
+package com.project.yozmcafe.domain.menu;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import jakarta.persistence.*;
+
+@Entity
+public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Cafe cafe;
+    private String name;
+    private String imageUrl;
+    private String description;
+    private String price;
+    private boolean isRecommended;
+}

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/Menu.java
@@ -9,18 +9,6 @@ import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MENU_PRICE;
 import static io.micrometer.common.util.StringUtils.isBlank;
 
 @Entity
-@Table(
-    name = "Menu",
-    uniqueConstraints = {
-        @UniqueConstraint(
-            name = "UK_cafe_priority",
-            columnNames = {
-                "cafe_id",
-                "priority"
-            }
-        )
-    }
-)
 public class Menu {
 
     public static final int MAX_NAME_LENGTH = 20;

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
@@ -9,16 +9,16 @@ import static io.micrometer.common.util.StringUtils.isBlank;
 
 @Entity
 @Table(
-        name = "MenuBoard",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_cafe_priority",
-                        columnNames = {
-                                "cafe_id",
-                                "priority"
-                        }
-                )
-        }
+    name = "MenuBoard",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "UK_cafe_priority",
+            columnNames = {
+                "cafe_id",
+                "priority"
+            }
+        )
+    }
 )
 public class MenuBoard {
 

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
@@ -1,0 +1,37 @@
+package com.project.yozmcafe.domain.menu;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import jakarta.persistence.*;
+
+@Entity
+public class MenuBoard {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Cafe cafe;
+
+    private String imageUrl;
+
+    public MenuBoard() {
+    }
+
+    public MenuBoard(final Long id, final Cafe cafe, final String imageUrl) {
+        this.id = id;
+        this.cafe = cafe;
+        this.imageUrl = imageUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Cafe getCafe() {
+        return cafe;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+}

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
@@ -1,10 +1,15 @@
 package com.project.yozmcafe.domain.menu;
 
 import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.exception.BadRequestException;
 import jakarta.persistence.*;
+
+import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MENU_BOARD_IMAGE;
+import static io.micrometer.common.util.StringUtils.isBlank;
 
 @Entity
 public class MenuBoard {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -12,15 +17,31 @@ public class MenuBoard {
     @ManyToOne
     private Cafe cafe;
 
+    @Column(nullable = false)
+    private Long priority;
+
+    @Column(nullable = false)
     private String imageUrl;
 
     public MenuBoard() {
     }
 
-    public MenuBoard(final Long id, final Cafe cafe, final String imageUrl) {
+    public MenuBoard(final Cafe cafe, final Long priority, final String imageUrl) {
+        this(null, cafe, priority, imageUrl);
+    }
+
+    public MenuBoard(final Long id, final Cafe cafe, final Long priority, final String imageUrl) {
+        validate(imageUrl);
         this.id = id;
+        this.priority = priority;
         this.cafe = cafe;
         this.imageUrl = imageUrl;
+    }
+
+    private void validate(final String imageUrl) {
+        if (isBlank(imageUrl)) {
+            throw new BadRequestException(NOT_EXISTED_MENU_BOARD_IMAGE);
+        }
     }
 
     public Long getId() {
@@ -29,6 +50,10 @@ public class MenuBoard {
 
     public Cafe getCafe() {
         return cafe;
+    }
+
+    public Long getPriority() {
+        return priority;
     }
 
     public String getImageUrl() {

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
@@ -26,7 +26,7 @@ public class MenuBoard {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Cafe cafe;
 
     @Column(nullable = false)

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
@@ -8,18 +8,6 @@ import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MENU_BOARD_IM
 import static io.micrometer.common.util.StringUtils.isBlank;
 
 @Entity
-@Table(
-    name = "MenuBoard",
-    uniqueConstraints = {
-        @UniqueConstraint(
-            name = "UK_cafe_priority",
-            columnNames = {
-                "cafe_id",
-                "priority"
-            }
-        )
-    }
-)
 public class MenuBoard {
 
     @Id
@@ -30,7 +18,7 @@ public class MenuBoard {
     private Cafe cafe;
 
     @Column(nullable = false)
-    private Long priority;
+    private int priority;
 
     @Column(nullable = false)
     private String imageUrl;
@@ -38,11 +26,11 @@ public class MenuBoard {
     public MenuBoard() {
     }
 
-    public MenuBoard(final Cafe cafe, final Long priority, final String imageUrl) {
+    public MenuBoard(final Cafe cafe, final int priority, final String imageUrl) {
         this(null, cafe, priority, imageUrl);
     }
 
-    public MenuBoard(final Long id, final Cafe cafe, final Long priority, final String imageUrl) {
+    public MenuBoard(final Long id, final Cafe cafe, final int priority, final String imageUrl) {
         validate(imageUrl);
         this.id = id;
         this.priority = priority;
@@ -64,7 +52,7 @@ public class MenuBoard {
         return cafe;
     }
 
-    public Long getPriority() {
+    public int getPriority() {
         return priority;
     }
 

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoard.java
@@ -8,6 +8,18 @@ import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_MENU_BOARD_IM
 import static io.micrometer.common.util.StringUtils.isBlank;
 
 @Entity
+@Table(
+        name = "MenuBoard",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "UK_cafe_priority",
+                        columnNames = {
+                                "cafe_id",
+                                "priority"
+                        }
+                )
+        }
+)
 public class MenuBoard {
 
     @Id

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoardRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuBoardRepository.java
@@ -1,0 +1,9 @@
+package com.project.yozmcafe.domain.menu;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MenuBoardRepository extends JpaRepository<MenuBoard, Long> {
+    List<MenuBoard> findAllByCafeIdOrderByPriorityAsc(Long cafeId);
+}

--- a/server/src/main/java/com/project/yozmcafe/domain/menu/MenuRepository.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/menu/MenuRepository.java
@@ -1,0 +1,9 @@
+package com.project.yozmcafe.domain.menu;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+    List<Menu> findAllByCafeIdOrderByIsRecommendedDescPriorityAsc(Long cafeId);
+}

--- a/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
+++ b/server/src/main/java/com/project/yozmcafe/exception/ErrorCode.java
@@ -29,7 +29,11 @@ public enum ErrorCode {
 
     INVALID_OAUTH_USER_INFO("O1", "Provider로 부터 받은 사용자 정보의 확인이 필요합니다."),
     NOT_EXISTED_OAUTH_PROVIDER("O2", "잘못된 Provider Name 입니다."),
-    NOT_EXISTED_OAUTH_CLIENT("O3", "일치하는 OAuthClient가 존재하지 않습니다.");
+    NOT_EXISTED_OAUTH_CLIENT("O3", "일치하는 OAuthClient가 존재하지 않습니다."),
+
+    INVALID_MENU_NAME("ME01", format("메뉴의 이름은 1 ~ %d자여야 합니다.", Cafe.NAME_MAX_LENGTH)),
+    NOT_EXISTED_MENU_PRICE("ME02", "메뉴 가격이 필요합니다."),
+    NOT_EXISTED_MENU_BOARD_IMAGE("ME03", "메뉴판 이미지가 필요합니다.");
 
     private final String code;
     private final String message;

--- a/server/src/main/java/com/project/yozmcafe/service/CafeAdminService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/CafeAdminService.java
@@ -65,6 +65,8 @@ public class CafeAdminService {
         Stream.of(
                         entityManager.createQuery("DELETE FROM UnViewedCafe u WHERE u.cafe.id = :cafeId"),
                         entityManager.createQuery("DELETE FROM LikedCafe l WHERE l.cafe.id = :cafeId"),
+                        entityManager.createQuery("DELETE FROM MenuBoard mb WHERE mb.cafe.id = :cafeId"),
+                        entityManager.createQuery("DELETE FROM Menu me WHERE me.cafe.id = :cafeId"),
                         entityManager.createQuery("DELETE FROM Cafe c WHERE c.id = :cafeId"))
                 .map(query -> query.setParameter("cafeId", cafeId))
                 .forEach(Query::executeUpdate);

--- a/server/src/main/java/com/project/yozmcafe/service/MenuService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/MenuService.java
@@ -6,10 +6,12 @@ import com.project.yozmcafe.domain.menu.MenuBoard;
 import com.project.yozmcafe.domain.menu.MenuBoardRepository;
 import com.project.yozmcafe.domain.menu.MenuRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
 public class MenuService {
 
     private final MenuRepository menuRepository;

--- a/server/src/main/java/com/project/yozmcafe/service/MenuService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/MenuService.java
@@ -1,0 +1,29 @@
+package com.project.yozmcafe.service;
+
+import com.project.yozmcafe.controller.dto.menu.MenuResponse;
+import com.project.yozmcafe.domain.menu.Menu;
+import com.project.yozmcafe.domain.menu.MenuBoard;
+import com.project.yozmcafe.domain.menu.MenuBoardRepository;
+import com.project.yozmcafe.domain.menu.MenuRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+    private final MenuBoardRepository menuBoardRepository;
+
+    public MenuService(final MenuRepository menuRepository, final MenuBoardRepository menuBoardRepository) {
+        this.menuRepository = menuRepository;
+        this.menuBoardRepository = menuBoardRepository;
+    }
+
+    public MenuResponse getMenus(final Long cafeId) {
+        final List<Menu> menus = menuRepository.findAllByCafeIdOrderByIsRecommendedDescPriorityAsc(cafeId);
+        final List<MenuBoard> menuBoards = menuBoardRepository.findAllByCafeIdOrderByPriorityAsc(cafeId);
+
+        return MenuResponse.of(cafeId, menuBoards, menus);
+    }
+}

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -58,14 +58,14 @@ create table if not exists `yozm-cafe`.un_viewed_cafe
 );
 
 create table if not exists `yozm-cafe`.menu (
-    is_recommended bit NOT NULL,
     id BIGINT NOT NULL AUTO_INCREMENT,
     cafe_id BIGINT,
     priority BIGINT NOT NULL,
-    description VARCHAR(255),
-    image_url VARCHAR(512),
     name VARCHAR(255) NOT NULL,
+    image_url VARCHAR(512),
+    description VARCHAR(255),
     price VARCHAR(255) NOT NULL,
+    is_recommended bit NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT menu_cafe_id
         foreign key (cafe_id) references cafe (id),

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -69,9 +69,7 @@ create table if not exists `yozm-cafe`.menu (
     PRIMARY KEY (id),
     CONSTRAINT menu_cafe_id
         foreign key (cafe_id) references cafe (id)
-            ON DELETE CASCADE,
-    CONSTRAINT UK_cafe_priority
-        UNIQUE (cafe_id, priority)
+            ON DELETE CASCADE
 );
 
 create table if not exists `yozm-cafe`.menu_board (
@@ -82,7 +80,5 @@ create table if not exists `yozm-cafe`.menu_board (
     PRIMARY KEY (id),
     CONSTRAINT menu_board_cafe_id
         foreign key (cafe_id) references cafe (id)
-            ON DELETE CASCADE,
-    CONSTRAINT UK_cafe_priority
-        UNIQUE (cafe_id, priority)
+            ON DELETE CASCADE
 );

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -59,7 +59,7 @@ create table if not exists `yozm-cafe`.un_viewed_cafe
 
 create table if not exists `yozm-cafe`.menu (
     id BIGINT NOT NULL AUTO_INCREMENT,
-    cafe_id BIGINT,
+    cafe_id BIGINT NOT NULL,
     priority INT NOT NULL,
     name VARCHAR(255) NOT NULL,
     image_url VARCHAR(512),
@@ -74,8 +74,8 @@ create table if not exists `yozm-cafe`.menu (
 
 create table if not exists `yozm-cafe`.menu_board (
     id BIGINT NOT NULL AUTO_INCREMENT,
-    cafe_id BIGINT,
-    priority BIGINT NOT NULL,
+    cafe_id BIGINT NOT NULL,
+    priority INT NOT NULL,
     image_url VARCHAR(512) NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT menu_board_cafe_id

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -56,3 +56,31 @@ create table if not exists `yozm-cafe`.un_viewed_cafe
     constraint un_viewed_cafe_MEMBER_ID
         foreign key (member_id) references member (id)
 );
+
+create table if not exists `yozm-cafe`.menu (
+    is_recommended bit NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    cafe_id BIGINT,
+    priority BIGINT NOT NULL,
+    description VARCHAR(255),
+    image_url VARCHAR(512),
+    name VARCHAR(255) NOT NULL,
+    price VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT menu_cafe_id
+        foreign key (cafe_id) references cafe (id),
+    CONSTRAINT UK_cafe_priority
+        UNIQUE (cafe_id, priority)
+);
+
+create table if not exists `yozm-cafe`.menu_board (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    cafe_id BIGINT,
+    priority BIGINT NOT NULL,
+    image_url VARCHAR(512) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT menu_board_cafe_id
+        foreign key (cafe_id) references cafe (id),
+    CONSTRAINT UK_cafe_priority
+        UNIQUE (cafe_id, priority)
+);

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -68,7 +68,8 @@ create table if not exists `yozm-cafe`.menu (
     is_recommended bit NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT menu_cafe_id
-        foreign key (cafe_id) references cafe (id),
+        foreign key (cafe_id) references cafe (id)
+            ON DELETE CASCADE,
     CONSTRAINT UK_cafe_priority
         UNIQUE (cafe_id, priority)
 );
@@ -80,7 +81,8 @@ create table if not exists `yozm-cafe`.menu_board (
     image_url VARCHAR(512) NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT menu_board_cafe_id
-        foreign key (cafe_id) references cafe (id),
+        foreign key (cafe_id) references cafe (id)
+            ON DELETE CASCADE,
     CONSTRAINT UK_cafe_priority
         UNIQUE (cafe_id, priority)
 );

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -60,7 +60,7 @@ create table if not exists `yozm-cafe`.un_viewed_cafe
 create table if not exists `yozm-cafe`.menu (
     id BIGINT NOT NULL AUTO_INCREMENT,
     cafe_id BIGINT,
-    priority BIGINT NOT NULL,
+    priority INT NOT NULL,
     name VARCHAR(255) NOT NULL,
     image_url VARCHAR(512),
     description VARCHAR(255),

--- a/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
@@ -37,7 +37,7 @@ class MenuControllerTest extends BaseControllerTest {
         final Cafe cafe = cafeRepository.save(Fixture.getCafe("오션카페", "선릉역", 1));
         final Menu savedMenu = menuRepository.save(new Menu(cafe, 1, "뜨거운 아이스 아메리카노",
                 "아메리카노.img", "뜨겁지만 차가워요", "5000", true));
-        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(cafe, 1L, "메뉴판"));
+        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(cafe, 1, "메뉴판"));
 
         //when
         final Response response = given(spec).log().all()

--- a/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
@@ -33,13 +33,13 @@ class MenuControllerTest extends BaseControllerTest {
     @Test
     @DisplayName("특정 카페의 메뉴와 메뉴판을 조회 한다.")
     void getMenus() {
-        Cafe cafe = cafeRepository.save(Fixture.getCafe("오션카페", "선릉역", 1));
-
+        //given
+        final Cafe cafe = cafeRepository.save(Fixture.getCafe("오션카페", "선릉역", 1));
         final Menu savedMenu = menuRepository.save(new Menu(cafe, 1, "뜨거운 아이스 아메리카노",
                 "아메리카노.img", "뜨겁지만 차가워요", "5000", true));
-
         final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(cafe, 1L, "메뉴판"));
 
+        //when
         final Response response = given(spec).log().all()
                 .filter(document("메뉴/메뉴 조회",
                         pathParameters(
@@ -61,6 +61,7 @@ class MenuControllerTest extends BaseControllerTest {
                 .when()
                 .get("/cafes/{cafeId}/menus", cafe.getId());
 
+        //then
         assertAll(
                 () -> assertThat(response.jsonPath().getString("menus[0].name")).isEqualTo(savedMenu.getName()),
                 () -> assertThat(response.jsonPath().getString("menus[0].imageUrl")).isEqualTo(savedMenu.getImageUrl()),

--- a/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
@@ -35,7 +35,7 @@ class MenuControllerTest extends BaseControllerTest {
     void getMenus() {
         Cafe cafe = cafeRepository.save(Fixture.getCafe("오션카페", "선릉역", 1));
 
-        final Menu savedMenu = menuRepository.save(new Menu(cafe, 1L, "뜨거운 아이스 아메리카노",
+        final Menu savedMenu = menuRepository.save(new Menu(cafe, 1, "뜨거운 아이스 아메리카노",
                 "아메리카노.img", "뜨겁지만 차가워요", "5000", true));
 
         final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(cafe, 1L, "메뉴판"));

--- a/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/controller/MenuControllerTest.java
@@ -1,0 +1,71 @@
+package com.project.yozmcafe.controller;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.CafeRepository;
+import com.project.yozmcafe.domain.menu.Menu;
+import com.project.yozmcafe.domain.menu.MenuBoard;
+import com.project.yozmcafe.domain.menu.MenuBoardRepository;
+import com.project.yozmcafe.domain.menu.MenuRepository;
+import com.project.yozmcafe.fixture.Fixture;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+
+class MenuControllerTest extends BaseControllerTest {
+
+    @Autowired
+    private CafeRepository cafeRepository;
+    @Autowired
+    private MenuRepository menuRepository;
+    @Autowired
+    private MenuBoardRepository menuBoardRepository;
+
+    @Test
+    @DisplayName("특정 카페의 메뉴와 메뉴판을 조회 한다.")
+    void getMenus() {
+        Cafe cafe = cafeRepository.save(Fixture.getCafe("오션카페", "선릉역", 1));
+
+        final Menu savedMenu = menuRepository.save(new Menu(cafe, 1L, "뜨거운 아이스 아메리카노",
+                "아메리카노.img", "뜨겁지만 차가워요", "5000", true));
+
+        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(cafe, 1L, "메뉴판"));
+
+        final Response response = given(spec).log().all()
+                .filter(document("메뉴/메뉴 조회",
+                        pathParameters(
+                                parameterWithName("cafeId").description("카페 ID")
+                        ), responseFields(
+                                fieldWithPath("cafeId").description("카페 ID"),
+                                fieldWithPath("menuBoards[].id").description("메뉴판 ID"),
+                                fieldWithPath("menuBoards[].priority").description("메뉴판 우선순위"),
+                                fieldWithPath("menuBoards[].imageUrl").description("메뉴판 이미지 url"),
+                                fieldWithPath("menus[].id").description("메뉴 ID"),
+                                fieldWithPath("menus[].priority").description("메뉴 우선순위"),
+                                fieldWithPath("menus[].name").description("메뉴 이름"),
+                                fieldWithPath("menus[].imageUrl").description("메뉴 이미지 url"),
+                                fieldWithPath("menus[].description").description("메뉴 설명"),
+                                fieldWithPath("menus[].price").description("메뉴 가격"),
+                                fieldWithPath("menus[].isRecommended").description("대표 메뉴 여부")
+                        )
+                ))
+                .when()
+                .get("/cafes/{cafeId}/menus", cafe.getId());
+
+        assertAll(
+                () -> assertThat(response.jsonPath().getString("menus[0].name")).isEqualTo(savedMenu.getName()),
+                () -> assertThat(response.jsonPath().getString("menus[0].imageUrl")).isEqualTo(savedMenu.getImageUrl()),
+                () -> assertThat(response.jsonPath().getString("menus[0].description")).isEqualTo(savedMenu.getDescription()),
+                () -> assertThat(response.jsonPath().getString("menuBoards[0].imageUrl")).isEqualTo(savedMenuBoard.getImageUrl())
+        );
+    }
+}

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
@@ -1,0 +1,23 @@
+package com.project.yozmcafe.domain.menu;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.exception.BadRequestException;
+import com.project.yozmcafe.exception.ErrorCode;
+import com.project.yozmcafe.fixture.Fixture;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MenuBoardTest {
+
+    @ParameterizedTest(name = "메뉴판 이미지가 공백이면 예외가 발생한다.")
+    @NullAndEmptySource
+    void invalidImageUrl(String imageUrl) {
+        final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
+
+        assertThatThrownBy(() -> new MenuBoard(cafe, 1L, imageUrl))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.NOT_EXISTED_MENU_BOARD_IMAGE.getMessage());
+    }
+}

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
@@ -14,8 +14,10 @@ class MenuBoardTest {
     @ParameterizedTest(name = "메뉴판 이미지가 공백이면 예외가 발생한다.")
     @NullAndEmptySource
     void invalidImageUrl(String imageUrl) {
+        //given
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
+        //when & then
         assertThatThrownBy(() -> new MenuBoard(cafe, 1L, imageUrl))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.NOT_EXISTED_MENU_BOARD_IMAGE.getMessage());

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
@@ -18,7 +18,7 @@ class MenuBoardTest {
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
         //when & then
-        assertThatThrownBy(() -> new MenuBoard(cafe, 1L, imageUrl))
+        assertThatThrownBy(() -> new MenuBoard(cafe, 1, imageUrl))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.NOT_EXISTED_MENU_BOARD_IMAGE.getMessage());
     }

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuBoardTest.java
@@ -13,7 +13,7 @@ class MenuBoardTest {
 
     @ParameterizedTest(name = "메뉴판 이미지가 공백이면 예외가 발생한다.")
     @NullAndEmptySource
-    void invalidImageUrl(String imageUrl) {
+    void invalidImageUrl(final String imageUrl) {
         //given
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
@@ -1,0 +1,47 @@
+package com.project.yozmcafe.domain.menu;
+
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.exception.BadRequestException;
+import com.project.yozmcafe.exception.ErrorCode;
+import com.project.yozmcafe.fixture.Fixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MenuTest {
+    @ParameterizedTest(name = "메뉴의 이름이 공백이면 예외가 발생한다.")
+    @NullAndEmptySource
+    void invalidName(String name) {
+        final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
+
+        assertThatThrownBy(() -> new Menu(cafe, 1L, name, "아메리카노.img", "고소한 아메리카노", "5000",
+                true))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.INVALID_MENU_NAME.getMessage());
+    }
+
+    @Test
+    @DisplayName("메뉴 이름 길이가 " + Menu.MAX_NAME_LENGTH + "를 초과하면 예외가 발생한다.")
+    void invalidNameLength() {
+        final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
+
+        assertThatThrownBy(() -> new Menu(cafe, 1L, "따뜻하면서도차갑고식지않는아이스아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+                true))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.INVALID_MENU_NAME.getMessage());
+    }
+
+    @ParameterizedTest(name = "메뉴 가격이 공백이면 예외가 발생한다.")
+    @NullAndEmptySource
+    void invalidPrice(String price) {
+        final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
+
+        assertThatThrownBy(() -> new Menu(cafe, 1L, "따듯한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노",
+                price, true))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.NOT_EXISTED_MENU_PRICE.getMessage());
+    }
+}

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
@@ -17,7 +17,7 @@ class MenuTest {
     void invalidName(String name) {
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
-        assertThatThrownBy(() -> new Menu(cafe, 1L, name, "아메리카노.img", "고소한 아메리카노", "5000",
+        assertThatThrownBy(() -> new Menu(cafe, 1, name, "아메리카노.img", "고소한 아메리카노", "5000",
                 true))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.INVALID_MENU_NAME.getMessage());
@@ -28,7 +28,7 @@ class MenuTest {
     void invalidNameLength() {
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
-        assertThatThrownBy(() -> new Menu(cafe, 1L, "따뜻하면서도차갑고식지않는아이스아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+        assertThatThrownBy(() -> new Menu(cafe, 1, "따뜻하면서도차갑고식지않는아이스아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.INVALID_MENU_NAME.getMessage());
@@ -39,7 +39,7 @@ class MenuTest {
     void invalidPrice(String price) {
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
-        assertThatThrownBy(() -> new Menu(cafe, 1L, "따듯한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노",
+        assertThatThrownBy(() -> new Menu(cafe, 1, "따듯한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노",
                 price, true))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.NOT_EXISTED_MENU_PRICE.getMessage());

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
@@ -15,8 +15,10 @@ class MenuTest {
     @ParameterizedTest(name = "메뉴의 이름이 공백이면 예외가 발생한다.")
     @NullAndEmptySource
     void invalidName(String name) {
+        //given
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
+        //when & then
         assertThatThrownBy(() -> new Menu(cafe, 1, name, "아메리카노.img", "고소한 아메리카노", "5000",
                 true))
                 .isInstanceOf(BadRequestException.class)
@@ -26,8 +28,10 @@ class MenuTest {
     @Test
     @DisplayName("메뉴 이름 길이가 " + Menu.MAX_NAME_LENGTH + "를 초과하면 예외가 발생한다.")
     void invalidNameLength() {
+        //given
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
+        //when & then
         assertThatThrownBy(() -> new Menu(cafe, 1, "따뜻하면서도차갑고식지않는아이스아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true))
                 .isInstanceOf(BadRequestException.class)
@@ -37,8 +41,10 @@ class MenuTest {
     @ParameterizedTest(name = "메뉴 가격이 공백이면 예외가 발생한다.")
     @NullAndEmptySource
     void invalidPrice(String price) {
+        //given
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
+        //when & then
         assertThatThrownBy(() -> new Menu(cafe, 1, "따듯한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노",
                 price, true))
                 .isInstanceOf(BadRequestException.class)

--- a/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/menu/MenuTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class MenuTest {
     @ParameterizedTest(name = "메뉴의 이름이 공백이면 예외가 발생한다.")
     @NullAndEmptySource
-    void invalidName(String name) {
+    void invalidName(final String name) {
         //given
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 
@@ -40,7 +40,7 @@ class MenuTest {
 
     @ParameterizedTest(name = "메뉴 가격이 공백이면 예외가 발생한다.")
     @NullAndEmptySource
-    void invalidPrice(String price) {
+    void invalidPrice(final String price) {
         //given
         final Cafe cafe = Fixture.getCafe("오션카페", "서울카페", 0);
 

--- a/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
@@ -36,7 +36,7 @@ class MenuServiceTest {
     @DisplayName("특정 카페의 메뉴판과 메뉴 목록을 조회한다.")
     void getMenus() {
         final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션카페", "서울카페", 0));
-        final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1L, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+        final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true));
         final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));
 
@@ -53,9 +53,9 @@ class MenuServiceTest {
     @DisplayName("카페의 메뉴판과 메뉴 목록은 isRecommend, priority 순으로 정렬하여 조회한다.")
     void getMenus_sort() {
         final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션카페", "서울카페", 0));
-        final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1L, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+        final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 false));
-        final Menu savedMenu2 = menuRepository.save(new Menu(savedCafe, 2L, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+        final Menu savedMenu2 = menuRepository.save(new Menu(savedCafe, 2, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true));
 
         final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));

--- a/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
@@ -39,7 +39,7 @@ class MenuServiceTest {
         final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션카페", "서울카페", 0));
         final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true));
-        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));
+        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1, "메뉴판 이미지"));
 
         //when
         final MenuResponse menuResponse = menuService.getMenus(savedCafe.getId());
@@ -61,8 +61,8 @@ class MenuServiceTest {
                 false));
         final Menu savedMenu2 = menuRepository.save(new Menu(savedCafe, 2, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true));
-        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));
-        final MenuBoard savedMenuBoard2 = menuBoardRepository.save(new MenuBoard(savedCafe, 2L, "메뉴판 이미지"));
+        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1, "메뉴판 이미지"));
+        final MenuBoard savedMenuBoard2 = menuBoardRepository.save(new MenuBoard(savedCafe, 2, "메뉴판 이미지"));
 
         //when
         final MenuResponse menuResponse = menuService.getMenus(savedCafe.getId());

--- a/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
@@ -35,13 +35,16 @@ class MenuServiceTest {
     @Test
     @DisplayName("특정 카페의 메뉴판과 메뉴 목록을 조회한다.")
     void getMenus() {
+        //given
         final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션카페", "서울카페", 0));
         final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true));
         final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));
 
+        //when
         final MenuResponse menuResponse = menuService.getMenus(savedCafe.getId());
 
+        //then
         assertAll(
                 () -> assertThat(menuResponse.cafeId()).isEqualTo(savedCafe.getId()),
                 () -> assertThat(menuResponse.menuBoards()).containsExactly(MenuBoardResponse.from(savedMenuBoard)),
@@ -52,17 +55,19 @@ class MenuServiceTest {
     @Test
     @DisplayName("카페의 메뉴판과 메뉴 목록은 isRecommend, priority 순으로 정렬하여 조회한다.")
     void getMenus_sort() {
+        //given
         final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션카페", "서울카페", 0));
         final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 false));
         final Menu savedMenu2 = menuRepository.save(new Menu(savedCafe, 2, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
                 true));
-
         final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));
         final MenuBoard savedMenuBoard2 = menuBoardRepository.save(new MenuBoard(savedCafe, 2L, "메뉴판 이미지"));
 
+        //when
         final MenuResponse menuResponse = menuService.getMenus(savedCafe.getId());
 
+        //then
         assertAll(
                 () -> assertThat(menuResponse.cafeId()).isEqualTo(savedCafe.getId()),
                 () -> assertThat(menuResponse.menuBoards()).containsExactly(MenuBoardResponse.from(savedMenuBoard),

--- a/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/MenuServiceTest.java
@@ -1,0 +1,74 @@
+package com.project.yozmcafe.service;
+
+import com.project.yozmcafe.controller.dto.menu.MenuBoardResponse;
+import com.project.yozmcafe.controller.dto.menu.MenuItemResponse;
+import com.project.yozmcafe.controller.dto.menu.MenuResponse;
+import com.project.yozmcafe.domain.cafe.Cafe;
+import com.project.yozmcafe.domain.cafe.CafeRepository;
+import com.project.yozmcafe.domain.menu.Menu;
+import com.project.yozmcafe.domain.menu.MenuBoard;
+import com.project.yozmcafe.domain.menu.MenuBoardRepository;
+import com.project.yozmcafe.domain.menu.MenuRepository;
+import com.project.yozmcafe.fixture.Fixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Transactional
+class MenuServiceTest {
+
+    @Autowired
+    private MenuService menuService;
+    @Autowired
+    private MenuRepository menuRepository;
+    @Autowired
+    private MenuBoardRepository menuBoardRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("특정 카페의 메뉴판과 메뉴 목록을 조회한다.")
+    void getMenus() {
+        final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션카페", "서울카페", 0));
+        final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1L, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+                true));
+        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));
+
+        final MenuResponse menuResponse = menuService.getMenus(savedCafe.getId());
+
+        assertAll(
+                () -> assertThat(menuResponse.cafeId()).isEqualTo(savedCafe.getId()),
+                () -> assertThat(menuResponse.menuBoards()).containsExactly(MenuBoardResponse.from(savedMenuBoard)),
+                () -> assertThat(menuResponse.menus()).containsExactly(MenuItemResponse.from(savedMenu))
+        );
+    }
+
+    @Test
+    @DisplayName("카페의 메뉴판과 메뉴 목록은 isRecommend, priority 순으로 정렬하여 조회한다.")
+    void getMenus_sort() {
+        final Cafe savedCafe = cafeRepository.save(Fixture.getCafe("오션카페", "서울카페", 0));
+        final Menu savedMenu = menuRepository.save(new Menu(savedCafe, 1L, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+                false));
+        final Menu savedMenu2 = menuRepository.save(new Menu(savedCafe, 2L, "따뜻한 아이스 아메리카노", "아메리카노.img", "고소한 아메리카노", "5000",
+                true));
+
+        final MenuBoard savedMenuBoard = menuBoardRepository.save(new MenuBoard(savedCafe, 1L, "메뉴판 이미지"));
+        final MenuBoard savedMenuBoard2 = menuBoardRepository.save(new MenuBoard(savedCafe, 2L, "메뉴판 이미지"));
+
+        final MenuResponse menuResponse = menuService.getMenus(savedCafe.getId());
+
+        assertAll(
+                () -> assertThat(menuResponse.cafeId()).isEqualTo(savedCafe.getId()),
+                () -> assertThat(menuResponse.menuBoards()).containsExactly(MenuBoardResponse.from(savedMenuBoard),
+                        MenuBoardResponse.from(savedMenuBoard2)),
+                () -> assertThat(menuResponse.menus()).containsExactly(MenuItemResponse.from(savedMenu2),
+                        MenuItemResponse.from(savedMenu))
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #325

## 📝 작업 내용

> 먼저 저희는 메뉴, 메뉴판 을 한 뷰에서 사용자에게 전달하기로 하였습니다. 이들은 모두 여러개가 될 수 있습니다.
> 메뉴, 메뉴판 들은 priority라는 우선순위를 가지고 이 순서에 따라 값을 출력합니다.
> 메뉴 는 isRecommend라는 시그니처 메뉴를 나타냅니다. 백엔드에서 전달할 때 isRecommend 순, priority 순 으로 정렬하여 전달합니다.
> 
> 구조는 카페 와 메뉴, 카페 와 메뉴판이 1 : N 입니다.
> 카페 -> 메뉴 를 사용할 일이 없을 것 같아 단방향 매핑으로 진행하였습니다
> 자세한 명세서는 노션에서 확인할 수 있습니다!

## 💬 리뷰 요구사항
> 1. Menu와 MenuBoard 의 복합 unique 제약 조건
> cafeId당 priority 가 unique 해야 해서 조건을 걸어봤습니다.
> 아니면 정규화를 해야되는 것일까요 !? pk가 아닌 cafeId가 priority를 인지할 수 있으니 ... ?
> 2. Response
> 지금 구조를 보면 MenuResponse 정팩메 안에서 메뉴판과 메뉴 response를 생성해주고 있습니다.
> 계층 구조라고 생각해서 이렇게 진행하였는데 어떻게 생각하시는지 궁금합니다 ~
> 3. 메뉴는 식별자가 필요한가?
> 사실 Cafe 도메인 내부에서 값객체로 menu를 가지고 있어도 되지 않나? 라는 고민을 많이 했습니다.
> Cafe 와 menu는 생명주기도 같고 따로 엔티티를 만들지 않고 사용해도 되지 않나 라는 생각을 했는데 추후 관리될 여지가 있기 때문에 분리하였습니다. 그리고 만약 수정을 해야된다면 값만 단순히 수정해줄 수 없기에 remove후 add하는 방식으로 수정하며 모두 삭제하고 다시 insert 되기 때문에 엔티티를 분리하였습니다. 이부분은 어떻게 생각하는지 제일 궁금하네용


질문이 정말 많아졌네요 .. 
잘부탁드립니돵 감사합니돵