### PR TITLE
좋아요 랭킹에서 카페를 누르면 해당 카페에 대한 상세 정보가 안나오는 현상을 수정한다.

### DIFF
--- a/client/src/components/RankCard.tsx
+++ b/client/src/components/RankCard.tsx
@@ -8,7 +8,7 @@ const RankCard = (props: Rank) => {
   const navigate = useNavigate();
 
   const handleRankCardClick = () => {
-    navigate(`/cafe/${id}`);
+    navigate(`/cafes/${id}`);
   };
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #364 

## 📝 작업 내용

- 좋아요 랭킹 페이지에서 카페를 눌렀을 때의 카페 상세 페이지로 이동되는 url을 수정하였습니다.

## 💬 리뷰 요구사항
