### PR TITLE
랭킹 페이지 카드의 콘텐츠 간격이 다른 문제를 해결한다.

### DIFF
--- a/client/src/components/RankCard.tsx
+++ b/client/src/components/RankCard.tsx
@@ -61,11 +61,11 @@ const CafeDetailContainer = styled.div`
   cursor: pointer;
 
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
 
   width: 100%;
   margin: ${({ theme }) => theme.space[4]} ${({ theme }) => theme.space[7]} ${({ theme }) => theme.space[4]} 0;
-  padding: ${({ theme }) => theme.space[5]} ${({ theme }) => theme.space['2.5']};
+  padding: ${({ theme }) => theme.space['2.5']} ${({ theme }) => theme.space[5]};
 
   background-color: ${({ theme }) => theme.color.white};
   border-radius: 50px;

--- a/client/src/components/RankCard.tsx
+++ b/client/src/components/RankCard.tsx
@@ -1,6 +1,7 @@
 import { PiHeartFill } from 'react-icons/pi';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
+import { IMAGE_HOST } from '../environment';
 import type { Rank } from '../types';
 
 const RankCard = (props: Rank) => {
@@ -18,7 +19,7 @@ const RankCard = (props: Rank) => {
       </CafeRankContainer>
       <CafeDetailContainer>
         <CafeDetailSummaryContainer>
-          <Image src={image} alt={`${image}}의 이미지`} />
+          <Image src={`${IMAGE_HOST}/100/${image}`} alt={`${image}}의 이미지`} />
           <TitleAndAddressContainer>
             <Title>{name}</Title>
             <Address>{address}</Address>

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -70,6 +70,16 @@ export const handlers = [
     return res(ctx.status(200));
   }),
 
+  // 좋아요 순으로 랭킹 목록 조회
+  rest.get('/api/cafes/ranks', (req, res, ctx) => {
+    const PAGINATE_UNIT = 10;
+
+    const page = Number(req.url.searchParams.get('page') || 1);
+    const [start, end] = [PAGINATE_UNIT * (page - 1), PAGINATE_UNIT * page];
+
+    return res(ctx.status(200), ctx.json(RankCafes.slice(start, end)));
+  }),
+
   // 좋아요 한 목록 조회
   rest.get('/api/members/:memberId/liked-cafes', (req, res, ctx) => {
     const PAGINATE_UNIT = 15;
@@ -120,16 +130,6 @@ export const handlers = [
   rest.get('/api/cafes/:cafeId', (req, res, ctx) => {
     const cafeId = Number(req.params.cafeId);
     return res(ctx.status(200), ctx.json(cafes.find((cafe) => cafe.id === cafeId)));
-  }),
-
-  // 좋아요 순으로 랭킹 목록 조회
-  rest.get('/api/cafes/ranks', (req, res, ctx) => {
-    const PAGINATE_UNIT = 10;
-
-    const page = Number(req.url.searchParams.get('page') || 1);
-    const [start, end] = [PAGINATE_UNIT * (page - 1), PAGINATE_UNIT * page];
-
-    return res(ctx.status(200), ctx.json(RankCafes.slice(start, end)));
   }),
 
   // 좋아요 한 카페 목록 상세 조회


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

close #383 

## 📝 작업 내용

- [RankCard 컴포넌트 UI 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/373c166cf97af97a2a0e1d045c07b43b93a669d5)
- [좋아요 순으로 랭킹 목록을 조회하는 handlers 위치 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/cb239b94e4c4e0bccaa1c9f5b0a97139c4800b46)
- [RankCard 컴포넌트 이미지 url 수정](https://github.com/woowacourse-teams/2023-yozm-cafe/commit/2249470beb177e70edacb23187032432dcb03377)

## 💬 리뷰 요구사항
