### PR TITLE
좋아요 버튼을 눌렀을 때 카운트가 올라가지 않는 버그 수정

### DIFF
--- a/client/src/components/CafeActionBar.tsx
+++ b/client/src/components/CafeActionBar.tsx
@@ -35,7 +35,11 @@ const CafeActionBar = (props: CafeActionBarProps) => {
     <Container onClick={handlePreventClickPropagation}>
       <Action>
         <ShareButton url={`https://yozm.cafe/cafes/${cafe.id}`} />
-        <LikeButton likeCount={cafe.likeCount} active={isLiked} onChange={handleLikeCountIncrease} />
+        <LikeButton
+          likeCount={cafe.likeCount + (isLiked ? 1 : 0)}
+          active={isLiked}
+          onChange={handleLikeCountIncrease}
+        />
       </Action>
       <Action onClick={() => setIsMenuOpened(true)}>
         <ActionButton label="메뉴">


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #395

## 📝 작업 내용
* 좋아요 버튼을 눌렀을 때 카운트가 올라가지 않는 버그를 수정하였습니다.

## 💬 리뷰 요구사항