### PR TITLE
메뉴 바텀시트가 뷰포트를 넘어가는 오류 수정

### DIFF
--- a/client/src/components/CafeMenuBottomSheet.tsx
+++ b/client/src/components/CafeMenuBottomSheet.tsx
@@ -101,6 +101,7 @@ const Container = styled.div`
 
   width: 100%;
   height: 600px;
+  max-height: 100vh;
   padding: ${({ theme }) => theme.space[4]};
   padding-bottom: 0;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #389

## 📝 작업 내용
![image](https://github.com/woowacourse-teams/2023-yozm-cafe/assets/20203944/bbe193e1-42a9-4eda-9df9-e8cca4a56233)

메뉴 바텀시트가 뷰포트를 넘어가는 버그 수정

## 💬 리뷰 요구사항