### PR TITLE
cypress-io/github-action@v5 사용하여 E2E 테스팅하도록 수정

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -27,18 +27,8 @@ jobs:
         with:
           node-version: 18
 
-      - name: Cache node_modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install dependencies
         uses: cypress-io/github-action@v5
-        if: steps.cache.outputs.cache-hit != 'true'
         with:
           install-command: yarn --frozen-lockfile
           parallel: true

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -37,11 +37,12 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
+        uses: cypress-io/github-action@v5
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
-
-      - name: Build
-        run: yarn build
-
-      - name: E2E test
-        run: yarn test
+        with:
+          install-command: yarn --frozen-lockfile
+          parallel: true
+          build: yarn build
+          start: yarn start
+          wait-on: 'http://localhost:3000'
+          command: yarn cypress:run

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install dependencies
         uses: cypress-io/github-action@v5
         with:
+          working-directory: client
           install-command: yarn --frozen-lockfile
           parallel: true
           build: yarn build

--- a/client/package.json
+++ b/client/package.json
@@ -15,8 +15,7 @@
     "storybook": "cross-env NODE_ENV=development storybook dev -p 6006",
     "build:storybook": "cross-env NODE_ENV=production storybook build",
     "cypress:open": "cypress open --e2e --browser chrome",
-    "cypress:run": "cypress run --e2e --browser chrome --headless",
-    "test": "start-server-and-test start http://localhost:3000 cypress:run"
+    "cypress:run": "cypress run --e2e --browser chrome --headless"
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.19",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #409

## 📝 작업 내용
* GitHub Actions cypress E2E 테스팅 시 cypress-io/github-action@v5 을 사용하도록 수정하였습니다.

## 💬 리뷰 요구사항