### PR TITLE
메뉴판 이미지로 보기 버튼에 이미지가 표시되지 않는 오류 수정

### DIFF
--- a/client/src/components/CafeMenuBottomSheet.tsx
+++ b/client/src/components/CafeMenuBottomSheet.tsx
@@ -150,7 +150,7 @@ const ShowMenuBoardButton = styled.button<{ $imageUrl: string }>`
   color: ${({ theme }) => theme.color.white};
 
   background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)),
-    url(${({ $imageUrl }) => Image.getUrl({ size: '500', filename: $imageUrl })});
+    url(${({ $imageUrl }) => Image.getUrl({ size: 'original', filename: $imageUrl })});
   background-repeat: no-repeat;
   background-position: center;
   background-size: 100%;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #419

## 📝 작업 내용
![image](https://github.com/woowacourse-teams/2023-yozm-cafe/assets/20203944/7885e912-301e-409e-a946-5b14efed5eff)

* 메뉴판 이미지로 보기 버튼에 이미지가 표시되지 않는 오류를 수정하였습니다.

## 💬 리뷰 요구사항