### PR TITLE
이미지 리사이즈 성능개선 및 이미지 서비스 리팩토링

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/controller/CafeAdminController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/CafeAdminController.java
@@ -22,7 +22,6 @@ import com.project.yozmcafe.controller.dto.cafe.CafeResponse;
 import com.project.yozmcafe.controller.dto.cafe.CafeUpdateRequest;
 import com.project.yozmcafe.controller.dto.cafe.MenuBoardRequest;
 import com.project.yozmcafe.controller.dto.cafe.MenuRequest;
-import com.project.yozmcafe.domain.resizedimage.Size;
 import com.project.yozmcafe.service.CafeAdminService;
 import com.project.yozmcafe.service.ImageService;
 import com.project.yozmcafe.service.MenuService;
@@ -45,7 +44,7 @@ public class CafeAdminController {
     @PostMapping
     public ResponseEntity<String> save(@RequestPart final CafeRequest request,
                                        @RequestPart final List<MultipartFile> images) {
-        final List<String> uploadedFileNames = imageService.resizeAndUpload(images, List.of(Size.values()));
+        final List<String> uploadedFileNames = imageService.resizeToAllSizesAndUpload(images);
         final Long savedId = cafeAdminService.save(request, uploadedFileNames);
 
         return ResponseEntity.created(URI.create("/admin/cafes/" + savedId)).build();
@@ -58,7 +57,7 @@ public class CafeAdminController {
         final List<String> originalImages = cafeAdminService.findImagesByCafeId(cafeId);
         imageService.deleteAll(originalImages);
 
-        final List<String> savedImages = imageService.resizeAndUpload(images, List.of(Size.values()));
+        final List<String> savedImages = imageService.resizeToAllSizesAndUpload(images);
         cafeAdminService.update(cafeId, request, savedImages);
 
         return ResponseEntity.noContent().build();
@@ -93,7 +92,7 @@ public class CafeAdminController {
             menuService.saveMenuWithoutImage(cafeId, menuRequest);
         }
         if (nonNull(image)) {
-            String uploadedFileName = imageService.resizeAndUpload(image, Size.THUMBNAIL);
+            String uploadedFileName = imageService.resizeToThumbnailSizeAndUpload(image);
             menuService.saveMenu(cafeId, menuRequest, uploadedFileName);
         }
 
@@ -104,7 +103,7 @@ public class CafeAdminController {
     public ResponseEntity<String> saveMenuBoards(@PathVariable("cafeId") final Long cafeId,
                                                  @RequestPart final MenuBoardRequest menuBoardRequest,
                                                  @RequestPart final MultipartFile image) {
-        String uploadedFileName = imageService.resizeAndUpload(image, Size.MOBILE);
+        String uploadedFileName = imageService.resizeToMobileSizeAndUpload(image);
         menuService.saveMenuBoard(cafeId, menuBoardRequest, uploadedFileName);
 
         return ResponseEntity.created(URI.create("/admin/cafes/" + cafeId)).build();

--- a/server/src/main/java/com/project/yozmcafe/controller/CafeAdminController.java
+++ b/server/src/main/java/com/project/yozmcafe/controller/CafeAdminController.java
@@ -92,7 +92,7 @@ public class CafeAdminController {
             menuService.saveMenuWithoutImage(cafeId, menuRequest);
         }
         if (nonNull(image)) {
-            String uploadedFileName = imageService.resizeToThumbnailSizeAndUpload(image);
+            final String uploadedFileName = imageService.resizeToThumbnailSizeAndUpload(image);
             menuService.saveMenu(cafeId, menuRequest, uploadedFileName);
         }
 
@@ -103,7 +103,7 @@ public class CafeAdminController {
     public ResponseEntity<String> saveMenuBoards(@PathVariable("cafeId") final Long cafeId,
                                                  @RequestPart final MenuBoardRequest menuBoardRequest,
                                                  @RequestPart final MultipartFile image) {
-        String uploadedFileName = imageService.resizeToMobileSizeAndUpload(image);
+        final String uploadedFileName = imageService.resizeToMobileSizeAndUpload(image);
         menuService.saveMenuBoard(cafeId, menuBoardRequest, uploadedFileName);
 
         return ResponseEntity.created(URI.create("/admin/cafes/" + cafeId)).build();

--- a/server/src/main/java/com/project/yozmcafe/domain/resizedimage/ImageResizer.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/resizedimage/ImageResizer.java
@@ -1,20 +1,23 @@
 package com.project.yozmcafe.domain.resizedimage;
 
-import com.project.yozmcafe.exception.BadRequestException;
-import org.springframework.web.multipart.MultipartFile;
+import static com.project.yozmcafe.exception.ErrorCode.INVALID_IMAGE_SIZE;
+import static com.project.yozmcafe.exception.ErrorCode.NOT_IMAGE;
+import static java.util.Objects.isNull;
+import static java.util.Objects.requireNonNull;
 
-import javax.imageio.ImageIO;
 import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
-import static com.project.yozmcafe.exception.ErrorCode.INVALID_IMAGE_SIZE;
-import static com.project.yozmcafe.exception.ErrorCode.NOT_IMAGE;
-import static java.util.Objects.isNull;
-import static java.util.Objects.requireNonNull;
+import javax.imageio.ImageIO;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.project.yozmcafe.exception.BadRequestException;
 
 public class ImageResizer {
 
@@ -46,13 +49,13 @@ public class ImageResizer {
         return !requireNonNull(contentType).startsWith(IMAGE_FORMAT_PREFIX);
     }
 
-    public List<MultipartFile> getResizedImages(final List<Size> sizes) {
-        return sizes.stream()
-                .map(this::getResizedImage)
+    public List<MultipartFile> resizeImageToAllSizes() {
+        return Arrays.stream(Size.values())
+                .map(this::resizeToFixedImage)
                 .toList();
     }
 
-    public MultipartFile getResizedImage(final Size size) {
+    public MultipartFile resizeToFixedImage(final Size size) {
         final BufferedImage bufferedImage = getBufferedImage();
 
         final int width = size.getWidth();

--- a/server/src/main/java/com/project/yozmcafe/domain/resizedimage/ImageResizer.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/resizedimage/ImageResizer.java
@@ -51,11 +51,11 @@ public class ImageResizer {
 
     public List<MultipartFile> resizeImageToAllSizes() {
         return Arrays.stream(Size.values())
-                .map(this::resizeToFixedImage)
+                .map(this::resizeToFixedSize)
                 .toList();
     }
 
-    public MultipartFile resizeToFixedImage(final Size size) {
+    public MultipartFile resizeToFixedSize(final Size size) {
         final BufferedImage bufferedImage = getBufferedImage();
 
         final int width = size.getWidth();

--- a/server/src/main/java/com/project/yozmcafe/service/ImageService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/ImageService.java
@@ -1,13 +1,14 @@
 package com.project.yozmcafe.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.project.yozmcafe.domain.S3Client;
 import com.project.yozmcafe.domain.resizedimage.ImageName;
 import com.project.yozmcafe.domain.resizedimage.ImageResizer;
 import com.project.yozmcafe.domain.resizedimage.Size;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Service
 public class ImageService {
@@ -23,7 +24,10 @@ public class ImageService {
                 .map(this::multipartfileToImageResizer)
                 .toList();
 
-        resizers.forEach(resizer -> resizer.getResizedImages(sizes).forEach(s3Client::upload));
+        resizers.parallelStream()
+                .forEach(resizer -> resizer.getResizedImages(sizes)
+                        .forEach(s3Client::upload)
+                );
 
         return resizers.stream()
                 .map(ImageResizer::getFileName)

--- a/server/src/main/java/com/project/yozmcafe/service/ImageService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/ImageService.java
@@ -42,17 +42,17 @@ public class ImageService {
     }
 
     public String resizeToThumbnailSizeAndUpload(MultipartFile file) {
-        return resizeToFixedImageAndUpload(file, THUMBNAIL);
+        return resizeToFixedSizeAndUpload(file, THUMBNAIL);
     }
 
     public String resizeToMobileSizeAndUpload(MultipartFile file) {
-        return resizeToFixedImageAndUpload(file, MOBILE);
+        return resizeToFixedSizeAndUpload(file, MOBILE);
     }
 
-    private String resizeToFixedImageAndUpload(final MultipartFile file, final Size size) {
+    private String resizeToFixedSizeAndUpload(final MultipartFile file, final Size size) {
         final ImageResizer imageResizer = multipartfileToImageResizer(file);
 
-        final MultipartFile resizedImages = imageResizer.resizeToFixedImage(size);
+        final MultipartFile resizedImages = imageResizer.resizeToFixedSize(size);
         s3Client.upload(resizedImages);
 
         return imageResizer.getFileName();

--- a/server/src/main/java/com/project/yozmcafe/service/MenuService.java
+++ b/server/src/main/java/com/project/yozmcafe/service/MenuService.java
@@ -48,7 +48,7 @@ public class MenuService {
         final Cafe cafe = cafeRepository.findById(cafeId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
 
-        Menu menu = menuRequest.toMenu(cafe, imageName);
+        final Menu menu = menuRequest.toMenu(cafe, imageName);
         menuRepository.save(menu);
     }
 
@@ -58,7 +58,7 @@ public class MenuService {
         final Cafe cafe = cafeRepository.findById(cafeId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
 
-        Menu menu = menuRequest.toMenuWithoutImage(cafe);
+        final Menu menu = menuRequest.toMenuWithoutImage(cafe);
         menuRepository.save(menu);
     }
 
@@ -69,7 +69,7 @@ public class MenuService {
         final Cafe cafe = cafeRepository.findById(cafeId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXISTED_CAFE));
 
-        MenuBoard menuBoard = menuBoardRequest.toMenu(cafe, imageName);
+        final MenuBoard menuBoard = menuBoardRequest.toMenu(cafe, imageName);
         menuBoardRepository.save(menuBoard);
     }
 }

--- a/server/src/test/java/com/project/yozmcafe/domain/ImageResizerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/ImageResizerTest.java
@@ -107,7 +107,7 @@ class ImageResizerTest {
         final ImageResizer imageResizer = new ImageResizer(image, fileName);
 
         //when
-        final MultipartFile resizedImage = imageResizer.resizeToFixedImage(size);
+        final MultipartFile resizedImage = imageResizer.resizeToFixedSize(size);
 
         //then
         assertThat(resizedImage.getOriginalFilename()).isEqualTo(size.getFileNameWithPath(fileName));

--- a/server/src/test/java/com/project/yozmcafe/domain/ImageResizerTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/ImageResizerTest.java
@@ -1,14 +1,8 @@
 package com.project.yozmcafe.domain;
 
-import com.project.yozmcafe.domain.resizedimage.ImageResizer;
-import com.project.yozmcafe.domain.resizedimage.Size;
-import com.project.yozmcafe.exception.BadRequestException;
-import com.project.yozmcafe.exception.ErrorCode;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -16,9 +10,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.project.yozmcafe.domain.resizedimage.ImageResizer;
+import com.project.yozmcafe.domain.resizedimage.Size;
+import com.project.yozmcafe.exception.BadRequestException;
+import com.project.yozmcafe.exception.ErrorCode;
 
 class ImageResizerTest {
 
@@ -75,14 +78,14 @@ class ImageResizerTest {
     }
 
     @Test
-    @DisplayName("리사이즈된 이미지들을 리턴한다")
-    void getResizedImages() throws Exception {
+    @DisplayName("모든 사이즈로 리사이즈된 이미지들을 리턴한다")
+    void resizeImageToAllSize() throws Exception {
         //given
         final MultipartFile image = makeMultipartFile();
         final ImageResizer imageResizer = new ImageResizer(image, "fileName.png");
 
         //when
-        final List<MultipartFile> results = imageResizer.getResizedImages(List.of(Size.values()));
+        final List<MultipartFile> results = imageResizer.resizeImageToAllSizes();
         final List<String> fileNameWithPathResult = results.stream()
                 .map(MultipartFile::getOriginalFilename)
                 .toList();
@@ -92,6 +95,22 @@ class ImageResizerTest {
                 "100/fileName.png",
                 "500/fileName.png"
         );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Size.class)
+    @DisplayName("특정 사이즈로 리사이즈된 이미지들을 리턴한다")
+    void resizeImageToMobileSize(final Size size) throws Exception {
+        //given
+        final String fileName = "fileName.png";
+        final MultipartFile image = makeMultipartFile();
+        final ImageResizer imageResizer = new ImageResizer(image, fileName);
+
+        //when
+        final MultipartFile resizedImage = imageResizer.resizeToFixedImage(size);
+
+        //then
+        assertThat(resizedImage.getOriginalFilename()).isEqualTo(size.getFileNameWithPath(fileName));
     }
 
     private MultipartFile makeMultipartFile() throws IOException {

--- a/server/src/test/java/com/project/yozmcafe/service/ImageServiceTest.java
+++ b/server/src/test/java/com/project/yozmcafe/service/ImageServiceTest.java
@@ -1,9 +1,18 @@
 package com.project.yozmcafe.service;
 
 
-import com.project.yozmcafe.BaseTest;
-import com.project.yozmcafe.domain.S3Client;
-import com.project.yozmcafe.domain.resizedimage.Size;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,17 +20,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.anyString;
-import static org.mockito.BDDMockito.times;
-import static org.mockito.BDDMockito.verify;
+import com.project.yozmcafe.BaseTest;
+import com.project.yozmcafe.domain.S3Client;
+import com.project.yozmcafe.domain.resizedimage.Size;
 
 class ImageServiceTest extends BaseTest {
 
@@ -32,14 +33,14 @@ class ImageServiceTest extends BaseTest {
     private S3Client s3Client;
 
     @Test
-    @DisplayName("리사이즈 이후 업로드 한다")
+    @DisplayName("모든 사이즈로 리사이즈 이후 업로드 한다")
     void resizeAndUpload1() {
         //given
         final MockMultipartFile image = makeMultipartFile();
         final List<MultipartFile> images = List.of(image, image, image);
 
         //when
-        final List<String> names = imageService.resizeAndUpload(images, List.of(Size.values()));
+        final List<String> names = imageService.resizeToAllSizesAndUpload(images);
 
         //then
         final int expectedUploadCount = images.size() * Size.values().length;
@@ -50,17 +51,16 @@ class ImageServiceTest extends BaseTest {
     }
 
     @Test
-    @DisplayName("리사이즈 이후 업로드한다")
+    @DisplayName("모바일 사이즈로 리사이즈 이후 업로드한다")
     void resizeAndUpload2() {
         //given
         final MockMultipartFile file = makeMultipartFile();
 
         //when
-        imageService.resizeAndUpload(file, Size.MOBILE);
+        imageService.resizeToMobileSizeAndUpload(file);
 
         //then
         verify(s3Client, times(1)).upload(any());
-
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> resolved #442 

## 📝 작업 내용

> [기존의 PR](https://github.com/woowacourse-teams/2023-yozm-cafe/pull/445)은 close 하고, 새로 올립니다.
> 이벤트는 사용하지 않고, `parallelStream`만 사용하여 기능개선을 해보았습니다.

## 💬 리뷰 요구사항
<img width="694" alt="image" src="https://github.com/woowacourse-teams/2023-yozm-cafe/assets/96301958/b7d98f02-9295-4e5d-8a1b-ded94018b362">

현재 구조가 위의 그림과 같은데요.

이걸
<img width="701" alt="image" src="https://github.com/woowacourse-teams/2023-yozm-cafe/assets/96301958/28471f87-44eb-4631-9930-560de377ec5b">

위와 같이 바꿔보려했습니다.
근데 이게 문제가 있더라구요.

### 이미지 업로드가 실패한다면?
사실 가능성이 적긴한데요. 모종의 이유로 s3업로드에 실패한다면 DB에는 이미지를 포함한 카페정보가 삽입되어있지만,
s3에는 업로드 되지 않아있기 때문에, 이미지 로드가 안될겁니다.
우리 서비스 특성상 카페의 이미지가 보여지지 않는다면, 조금 문제가 크다고 생각했어요.

그래서 추가적으로 생각한게, 업로드 과정 중에 Exception이 발생한다면 저장된 데이터를 삭제 해버리는 겁니다.
근데 이것도 문제가 있는게, 이렇게 처리된다면 이미 사용자는 정상적으로 데이터가 저장되었다는 응답을 받지만, 실제로는 저장이 안되어있는 상태겠죠?
이건 클라이언트 한테 거짓말 하는거잖아요.. 
그래서 원래의 구조를 유지하기로 했습니다.
이게 그나마 트랜잭션을 물고 있는 기간도 적고, 사용자에게 거짓말도 안해도 된다고 생각했어요.
이쁘게 봐주십쇼.

아 그리고 포크조인풀 관련한 포스팅은 이거 merge 되고 나면 성능 측정 다시해보고 마무리 지을게요
감사합니다.
