### PR TITLE
톰캣 설정값 변경

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -29,3 +29,6 @@ spring.flyway.baseline-version=20230901153300
 spring.flyway.baseline-on-migrate=true
 spring.flyway.out-of-order=true
 spring.jpa.properties.hibernate.default_batch_fetch_size=1000
+server.tomcat.max-connections=100
+server.tomcat.accept-count=50
+server.tomcat.threads.max=100


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #472 

## 📝 작업 내용
> ## 동시 요청을 보낼 가상 유저 수
- 목표로 하는 동시 유저 접속 유저 수를 100명으로 설정한다.

## 테스트 대상 API

- 가장 많이 호출되는 요청 - /cafes/guest?page=*

## 데이터베이스 더미 데이터 세팅

- 카페 10000

## 테스트 전략

- 현재 우리가 목표로 하는 동시 접속 유저 수는 서버에 많은 영향을 미칠 정도로 큰 값이 아니므로, Thread 관련 문제보다는 다른 구간에서 발생하는 병목으로 인해 maxThreads, maxConnections 값을 조정해도 성능이 더이상 개선되지 않는 구간이 나타날 것이다.

- 발생 확률이 거의 없는 비현실적인 상황을 대비해 설정값을 무작정 늘리면 불필요한 메모리가 낭비될 수 있으며, 만약 예상치 못한 큰 규모의 동시 요청이 실제로 온다고 해도 서버가 많은 양의 동시 요청을 감당하지 못해 터지거나 타임아웃이 발생할 수 있다.

→ maxThreads, maxConnections 값을 높여도 TPS 더이상 변화가 없는 구간을 찾는다. 해당 구간에서의 maxThreads, maxConnections 값을 현재 요즘카페 서비스에 적절한 설정값이라고 가정할 수 있다

### 1. maxThreads 값
- User - 100, acceptCount - 100(default), maxConnections - 8192(default)
- maxThreads 값을 높여도 더이상 성능 개선이 발상하지 않는 지점
테스트 결과 : 100

### 2. maxConnections 값
- User - 100, acceptCount - 100, maxThreads - 100
- 적절한 값의 기준 : 성능 저하가 발생하지 않으며 100개의 동시 요청을 감당할 수 있을 만큼 안전하다.
테스트 결과 : maxConnections가 100부터 유의미한 결과가 나타나지 않았다. User 수만큼 생성되는 각각의 테스트 Thread들은 요청을 보내면 해당 요청에 대한 응답을 받은 후에 다음 요청을 보내므로, 100개의 User가 동시에 요청을 연달아 보낸다고 해도 커넥션이 100 이상 연결되지는 않기 때문에 이런 결과가 나왔을 것 이라고 생각된다. (의견받음)

### 3. acceptCount 값 설정
- maxConnections 값을 우리가 가정한 user를 100에 딱 맞춘다면, 예상치 못한 100 이상의 동시 요청이 발생했을 때의 안정성을 보장하기 힘들다. 100의 절반인 50을 acceptCount 값으로 설정함으로써 이러한 상황을 방지하고자 하였다.
- acceptCount 값을 100으로 설정 후 위에서 진행한 테스트를 다시 진행했을 때, 기존에 acceptCount 값을 50으로 설정하고 진행했을 때와 크게 다르지 않은 성능 결과를 보였다.

### 결론
- maxConnections : 100
- acceptCount : 50
- maxThreads : 100

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
