### PR TITLE
Offset 관련 에러 해결

### DIFF
--- a/server/src/main/java/com/project/yozmcafe/domain/cafe/Images.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/cafe/Images.java
@@ -4,6 +4,7 @@ import com.project.yozmcafe.exception.BadRequestException;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
+import org.apache.logging.log4j.util.Strings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,10 @@ public class Images {
     }
 
     public String getRepresentativeImage() {
+        if (urls.isEmpty()) {
+            return Strings.EMPTY;
+        }
+
         return urls.get(REPRESENTATIVE_INDEX);
     }
 }

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_LIKED_CAFE;
@@ -100,6 +101,10 @@ public class Member {
     }
 
     public List<Cafe> getLikedCafes(final int startIndex, final int amount) {
+        if (startIndex >= likedCafes.size()) {
+            return Collections.emptyList();
+        }
+
         final List<Cafe> cafes = likedCafes.stream()
                 .map(LikedCafe::getCafe)
                 .toList();

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -11,13 +11,13 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static com.project.yozmcafe.exception.ErrorCode.NOT_EXISTED_LIKED_CAFE;
 import static jakarta.persistence.CascadeType.MERGE;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static java.lang.Math.min;
+import static java.util.Collections.emptyList;
 
 @Entity
 public class Member {
@@ -102,7 +102,7 @@ public class Member {
 
     public List<Cafe> getLikedCafes(final int startIndex, final int amount) {
         if (startIndex >= likedCafes.size()) {
-            return Collections.emptyList();
+            return emptyList();
         }
 
         final List<Cafe> cafes = likedCafes.stream()

--- a/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
+++ b/server/src/main/java/com/project/yozmcafe/domain/member/Member.java
@@ -99,12 +99,13 @@ public class Member {
         return result;
     }
 
-    public List<Cafe> getLikedCafes(final int startIndex, final int endIndex) {
+    public List<Cafe> getLikedCafes(final int startIndex, final int amount) {
         final List<Cafe> cafes = likedCafes.stream()
                 .map(LikedCafe::getCafe)
                 .toList();
 
-        return cafes.subList(startIndex, min(endIndex, this.likedCafes.size()));
+        final int endIndex = startIndex + amount;
+        return cafes.subList(startIndex, min(endIndex, cafes.size()));
     }
 
     public String getId() {

--- a/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
+++ b/server/src/test/java/com/project/yozmcafe/domain/member/MemberTest.java
@@ -194,7 +194,7 @@ class MemberTest {
 
     @Test
     @DisplayName("좋아요한 카페 목록을 페이지 처리한다")
-    void getLikedCafesSection() {
+    void getLikedCafes() {
         //given
         final Member member = new Member("1234", "오션", "오션사진");
         final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);
@@ -211,5 +211,35 @@ class MemberTest {
 
         //then
         assertThat(likedCafes).containsExactly(cafe1, cafe2);
+    }
+
+    @Test
+    @DisplayName("좋아요한 카페 목록을 조회할 때 없는 페이지를 요청하면 빈 리스트를 반환한다")
+    void getLikedCafes_empty() {
+        //given
+        final Member member = new Member("1234", "연어", "딱새우회_먹고싶다");
+
+        //when
+        final List<Cafe> likedCafes = member.getLikedCafes(0, 5);
+
+        //then
+        assertThat(likedCafes).isEmpty();
+    }
+
+    @Test
+    @DisplayName("좋아요한 카페 목록을 조회할 때 요청한 사이즈보다 적으면 있는 만큼만 반환한다")
+    void getLikedCafes_amount() {
+        //given
+        final Member member = new Member("1234", "연어", "딱새우회_먹고싶다");
+        final Cafe cafe1 = Fixture.getCafe(1L, "카페1", "주소1", 3);
+        final Cafe cafe2 = Fixture.getCafe(2L, "카페2", "주소2", 3);
+        member.updateLikedCafesBy(cafe1, true);
+        member.updateLikedCafesBy(cafe2, true);
+
+        //when
+        final List<Cafe> likedCafes = member.getLikedCafes(0, 5);
+
+        //then
+        assertThat(likedCafes).hasSize(2);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #468 

## 📝 작업 내용
- 해당 PR을 개발 서버에 배포한 이후 프로필 화면에서 에러 남
```java
2023-09-26 09:03:56 | http-nio-8080-exec-7 | [USER: anonymous] | ERROR | Exception Handler | Internal Error occurred
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:361)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at org.hibernate.collection.spi.PersistentBag.get(PersistentBag.java:537)
	at com.project.yozmcafe.domain.cafe.Images.getRepresentativeImage(Images.java:38)
	at com.project.yozmcafe.domain.cafe.Cafe.getRepresentativeImage(Cafe.java:108)
	at com.project.yozmcafe.controller.dto.cafe.CafeThumbnailResponse.from(CafeThumbnailResponse.java:8)
```
- 대표 이미지를 보여주는 로직에서 `urls.get(0)`를 호출하는데, 개발 서버에는 이미지 없는 카페들도 존재함
- 따라서 방어 로직 작성
- member의 LikedCafe를 sublist할 때 Pageable의 pageSize를 endIndex로 사용하고 있던 부분 수정

