### PR TITLE
MSW, 개발 서버 등 API 서버를 쉽게 변경할 수 있는 명령줄(CLI) 옵션 지원

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "solo5star <solo_5@naver.com>"
   ],
   "scripts": {
-    "start": "cross-env NODE_ENV=development webpack serve --config webpack.development.js",
+    "start": "node scripts/start.js",
     "build": "cross-env NODE_ENV=production webpack --config webpack.production.js",
     "storybook": "cross-env NODE_ENV=development storybook dev -p 6006",
     "build:storybook": "cross-env NODE_ENV=production storybook build",
@@ -45,6 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
     "babel-loader": "^9.1.2",
+    "commander": "^11.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "cross-env": "^7.0.3",
     "cypress": "^12.17.4",

--- a/client/scripts/start.js
+++ b/client/scripts/start.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { program } from 'commander';
+import webpack from 'webpack';
+import WebpackDevServer from 'webpack-dev-server';
+import webpackConfig from '../webpack.development.js';
+
+process.env.NODE_ENV = 'development';
+
+/** @type {Record<string, import('webpack-dev-server').ProxyConfigMap | null>} */
+const profiles = {
+  msw: {},
+  local: {
+    '/api': {
+      changeOrigin: true,
+      target: 'http://localhost:8080',
+      pathRewrite: {
+        '^/api': '',
+      },
+    },
+  },
+  dev: {
+    '/api': {
+      changeOrigin: true,
+      target: 'https://dev.yozm.cafe',
+    },
+    '/images': {
+      changeOrigin: true,
+      target: 'https://dev.yozm.cafe',
+    },
+  },
+  prod: {
+    '/api': {
+      changeOrigin: true,
+      target: 'https://yozm.cafe',
+    },
+    '/images': {
+      changeOrigin: true,
+      target: 'https://yozm.cafe',
+    },
+  },
+};
+
+program.option(
+  '--profile <profile>',
+  `API 서버 프로필을 지정합니다. ${Object.keys(profiles).join(', ')} 중 하나를 선택할 수 있습니다`,
+  'msw',
+);
+program.parse();
+
+const options = program.opts();
+const profile = profiles[options.profile];
+
+if (!profile) {
+  program.error(
+    `"${options.profile}"는 존재하지 않는 프로필입니다. ${Object.keys(profiles).join(', ')} 중 하나를 선택해주세요.`,
+  );
+}
+
+if (options.profile === 'msw') {
+  process.env.MSW = 'true';
+}
+
+const compiler = webpack(webpackConfig);
+const devServerConfig = {
+  ...webpackConfig.devServer,
+  proxy: profile,
+};
+const server = new WebpackDevServer(devServerConfig, compiler);
+
+const runServer = async () => {
+  console.log(`Starting server with profile ${options.profile}`);
+  await server.start();
+};
+
+runServer();

--- a/client/webpack.development.js
+++ b/client/webpack.development.js
@@ -2,8 +2,6 @@ import ReactRefreshPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import { merge } from 'webpack-merge';
 import webpackCommonConfig from './webpack.common.js';
 
-export const API_URL = process.env.API_URL ?? 'http://localhost:8080';
-
 /** @type {import('webpack').Configuration} */
 export default merge(webpackCommonConfig, {
   mode: 'development',
@@ -14,13 +12,5 @@ export default merge(webpackCommonConfig, {
     allowedHosts: 'all',
     historyApiFallback: true,
     open: true,
-    proxy: {
-      '/api': {
-        target: API_URL,
-        pathRewrite: {
-          '^/api': '',
-        },
-      },
-    },
   },
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #503 

## 📝 작업 내용
* 명령줄 옵션으로 msw, dev 서버, prod 서버를 스위칭할 수 있는 기능을 추가하였습니다.
* 이제 `yarn start --profile msw` 와 같은 식으로 msw, dev 서버를 쉽게 전환할 수 있습니다.
* `--profile` 옵션을 사용하지 않을 시 기본 값으로 `msw` 가 사용됩니다. (`yarn start`)

## 💬 리뷰 요구사항
커맨드 라인의 디자인이 어떤지 봐주세요~