### PR TITLE
네비게이션 바에 지도 아이콘 추가

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState } from 'react';
 import { FaSearch } from 'react-icons/fa';
-import { FaRankingStar } from 'react-icons/fa6';
+import { FaMapLocationDot, FaRankingStar } from 'react-icons/fa6';
 import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 import useUser from '../hooks/useUser';
@@ -33,6 +33,11 @@ const Navbar = () => {
         <Link to="/search">
           <IconButton>
             <FaSearch />
+          </IconButton>
+        </Link>
+        <Link to="/map">
+          <IconButton>
+            <FaMapLocationDot />
           </IconButton>
         </Link>
         <UserButtonContainer>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #550 

## 📝 작업 내용

<img width="498" alt="스크린샷 2023-10-11 오전 8 28 38" src="https://github.com/woowacourse-teams/2023-yozm-cafe/assets/122500517/3b02dc2d-9d4c-455e-b55e-97d6031cac96">

- 네비게이션 바에 지도 아이콘 추가 하였습니다.
- 기존의 아이콘들과 이질감이 없도록 `react-icons/fa6`에 있는 아이콘을 사용하였습니다.

## 💬 리뷰 요구사항

확인부탁드립니다^^
