### PR TITLE
일부 화면 비율에서 컨텐츠가 잘리는 오류 수정

### DIFF
--- a/client/src/components/CafeCard.tsx
+++ b/client/src/components/CafeCard.tsx
@@ -90,12 +90,13 @@ const CafeCard = (props: CardProps) => {
 
       <CarouselImageList onScroll={handleScroll}>
         {cafe.images.map((image, index) => (
-          <CarouselImage
-            key={index}
-            src={Resource.getImageUrl({ size: '500', filename: image })}
-            alt={`${cafe.name}의 ${index + 1}번째 이미지`}
-            loading={Math.abs(currentImageIndex - index) <= 1 ? 'eager' : 'lazy'}
-          />
+          <CarouselImageFrame key={index}>
+            <CarouselImage
+              src={Resource.getImageUrl({ size: '500', filename: image })}
+              alt={`${cafe.name}의 ${index + 1}번째 이미지`}
+              loading={Math.abs(currentImageIndex - index) <= 1 ? 'eager' : 'lazy'}
+            />
+          </CarouselImageFrame>
         ))}
       </CarouselImageList>
 
@@ -169,15 +170,22 @@ const CarouselImageList = styled.div`
   height: 100%;
 `;
 
-const CarouselImage = styled.img.attrs({ draggable: false })`
+const CarouselImageFrame = styled.div`
   scroll-snap-align: start;
   scroll-snap-stop: always;
 
+  position: relative;
+
   flex: 0 0 100%;
 
-  min-width: 100%;
+  width: 100%;
   height: 100%;
+`;
 
+const CarouselImage = styled.img.attrs({ draggable: false })`
+  position: absolute;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
 `;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #250 
resolve #518 
resolve #549 

## 📝 작업 내용
* 이미지의 크기 때문에 화면에서 컨텐츠가 잘리는 오류를 수정하였습니다.
* 이미지를 `position: absolute`로 두어 이미지 크기를 문맥에서 제거함으로서 해결할 수 있었습니다.

## 💬 리뷰 요구사항
