### PR TITLE
아이폰에서 상하좌우 동시에 스와이프되는 문제 수정

### DIFF
--- a/client/src/components/ScrollSnap/components/ScrollSnap.tsx
+++ b/client/src/components/ScrollSnap/components/ScrollSnap.tsx
@@ -2,7 +2,9 @@ import type { ScrollSnapProps } from '../types';
 import ScrollSnapCSS from './ScrollSnapCSS/ScrollSnapCSS';
 import ScrollSnapImpl from './ScrollSnapImpl/ScrollSnapImpl';
 
-const isMobile = window.navigator.userAgent.match(/(iPad)|(iPhone)|(iPod)|(android)|(webOS)/i);
+const isMobile = /(iPad)|(iPhone)|(iPod)|(android)|(webOS)/i.test(window.navigator.userAgent);
+
+const isIOS = /(iPad)|(iPhone)|(iPod)/i.test(window.navigator.userAgent);
 
 type ScrollSnapWithMode<Item> = ScrollSnapProps<Item> & {
   // auto일 시 userAgent의 값에 따라 mode를 결정
@@ -15,7 +17,10 @@ const ScrollSnap = <Item,>(props: ScrollSnapWithMode<Item>) => {
   const { mode = 'auto', ...restProps } = props;
 
   if (mode === 'auto') {
-    return isMobile ? <ScrollSnapImpl {...restProps} /> : <ScrollSnapCSS {...restProps} />;
+    if (isIOS) return <ScrollSnapCSS {...restProps} />;
+    if (isMobile) return <ScrollSnapImpl {...restProps} />;
+
+    return <ScrollSnapCSS {...restProps} />;
   }
   if (mode === 'css') {
     return <ScrollSnapCSS {...restProps} />;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #590 

## 📝 작업 내용
* 아이폰에서 상하좌우 동시에 스와이프되는 문제 수정
* CSS scroll-snap 모드로 동작하게 함으로서 고쳤습니다
* 향후 모든 축 스와이프를 JS Implementation으로 교체하면 해결할 수 있을 듯 합니다

## 💬 리뷰 요구사항